### PR TITLE
Port tests to JUnit 5

### DIFF
--- a/adapter-http/src/test/java/io/knotx/databridge/http/HttpClientFacadeTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/HttpClientFacadeTest.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 @ExtendWith(KnotxExtension.class)
@@ -139,8 +139,8 @@ public class HttpClientFacadeTest {
           Assertions.assertEquals(error.getClass().getSimpleName(),
               IllegalArgumentException.class.getSimpleName());
           Mockito.verify(mockedWebClient, Mockito.times(0))
-              .request(Matchers.any(), Matchers.anyInt(), Matchers.anyString(),
-                  Matchers.anyString());
+              .request(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyString(),
+                  ArgumentMatchers.anyString());
         })
         .subscribe(
             response -> context.failNow(new Exception("Error should occur!")),
@@ -166,8 +166,8 @@ public class HttpClientFacadeTest {
         .doOnError(error -> {
           Assertions.assertEquals(UnsupportedDataSourceException.class, error.getClass());
           Mockito.verify(mockedWebClient, Mockito.times(0))
-              .request(Matchers.any(), Matchers.anyInt(), Matchers.anyString(),
-                  Matchers.anyString());
+              .request(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyString(),
+                  ArgumentMatchers.anyString());
         })
         .subscribe(
             response -> context.failNow(new Exception("Error should occur!")),

--- a/adapter-http/src/test/java/io/knotx/databridge/http/HttpClientFacadeTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/HttpClientFacadeTest.java
@@ -23,33 +23,28 @@ import io.knotx.databridge.http.common.exception.UnsupportedDataSourceException;
 import io.knotx.databridge.http.common.http.HttpClientFacade;
 import io.knotx.dataobjects.ClientRequest;
 import io.knotx.dataobjects.ClientResponse;
-import io.knotx.junit.rule.KnotxConfiguration;
-import io.knotx.junit.rule.TestVertxDeployer;
-import io.knotx.junit.util.FileReader;
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
+import io.knotx.junit5.KnotxTestUtils;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.Single;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.ext.web.client.WebClient;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Pattern;
-
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(KnotxExtension.class)
 public class HttpClientFacadeTest {
 
   // Configuration
@@ -67,23 +62,16 @@ public class HttpClientFacadeTest {
   private static final List<Pattern> PATTERNS = Collections
       .singletonList(Pattern.compile("X-test*"));
 
-  private RunTestOnContext vertx = new RunTestOnContext();
-
-  private TestVertxDeployer knotx = new TestVertxDeployer(vertx);
-
-  @Rule
-  public RuleChain chain = RuleChain.outerRule(vertx).around(knotx);
 
   @Test
-  @KnotxConfiguration("knotx-datasource-http-test.json")
+  @KnotxApplyConfiguration("knotx-datasource-http-test.json")
   public void whenSupportedStaticPathServiceRequested_expectRequestExecutedAndResponseOKWithBody(
-      TestContext context) throws Exception {
-    Async async = context.async();
+      VertxTestContext context, Vertx vertx) throws Exception {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
-    final JsonObject expectedResponse = new JsonObject(FileReader.readText("first-response.json"));
+    final JsonObject expectedResponse = new JsonObject(KnotxTestUtils.readText("first-response.json"));
 
     // when
     Single<ClientResponse> result = clientFacade
@@ -92,27 +80,26 @@ public class HttpClientFacadeTest {
     // then
     result
         .doOnSuccess(response -> {
-          context.assertEquals(HttpResponseStatus.OK.code(), response.getStatusCode());
-          context.assertEquals(expectedResponse, response.getBody().toJsonObject());
+          Assertions.assertEquals(HttpResponseStatus.OK.code(), response.getStatusCode());
+          Assertions.assertEquals(expectedResponse, response.getBody().toJsonObject());
           Mockito.verify(mockedWebClient, Mockito.times(1))
               .request(HttpMethod.GET, PORT, DOMAIN, REQUEST_PATH);
         })
         .subscribe(
-            response -> async.complete(),
-            error -> context.fail(error.getMessage())
+            response -> context.completeNow(),
+            context::failNow
         );
   }
 
   @Test
-  @KnotxConfiguration("knotx-datasource-http-test.json")
+  @KnotxApplyConfiguration("knotx-datasource-http-test.json")
   public void whenSupportedDynamicPathServiceRequested_expectRequestExecutedAndResponseOKWithBody(
-      TestContext context) throws Exception {
-    Async async = context.async();
+      VertxTestContext context, Vertx vertx) throws Exception {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
-    final JsonObject expectedResponse = new JsonObject(FileReader.readText("first-response.json"));
+    final JsonObject expectedResponse = new JsonObject(KnotxTestUtils.readText("first-response.json"));
     final ClientRequest request = new ClientRequest()
         .setParams(MultiMap.caseInsensitiveMultiMap().add("dynamicValue", "first"));
 
@@ -124,24 +111,23 @@ public class HttpClientFacadeTest {
     // then
     result
         .doOnSuccess(response -> {
-          context.assertEquals(HttpResponseStatus.OK.code(), response.getStatusCode());
-          context.assertEquals(expectedResponse, response.getBody().toJsonObject());
+          Assertions.assertEquals(HttpResponseStatus.OK.code(), response.getStatusCode());
+          Assertions.assertEquals(expectedResponse, response.getBody().toJsonObject());
           Mockito.verify(mockedWebClient, Mockito.times(1))
               .request(HttpMethod.GET, PORT, DOMAIN, REQUEST_PATH);
         })
         .subscribe(
-            response -> async.complete(),
-            error -> context.fail(error.getMessage())
+            response -> context.completeNow(),
+            context::failNow
         );
   }
 
   @Test
-  @KnotxConfiguration("knotx-datasource-http-test.json")
+  @KnotxApplyConfiguration("knotx-datasource-http-test.json")
   public void whenServiceRequestedWithoutPathParam_expectNoServiceRequestAndBadRequest(
-      TestContext context) throws Exception {
-    Async async = context.async();
+      VertxTestContext context, Vertx vertx) throws Exception {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
 
@@ -151,24 +137,23 @@ public class HttpClientFacadeTest {
     // then
     result
         .doOnError(error -> {
-          context.assertEquals(error.getClass().getSimpleName(),
+          Assertions.assertEquals(error.getClass().getSimpleName(),
               IllegalArgumentException.class.getSimpleName());
           Mockito.verify(mockedWebClient, Mockito.times(0))
               .request(Matchers.any(), Matchers.anyInt(), Matchers.anyString(),
                   Matchers.anyString());
         })
         .subscribe(
-            response -> context.fail("Error should occur!"),
-            error -> async.complete());
+            response -> context.failNow(new Exception("Error should occur!")),
+            error -> context.completeNow());
   }
 
   @Test
-  @KnotxConfiguration("knotx-datasource-http-test.json")
+  @KnotxApplyConfiguration("knotx-datasource-http-test.json")
   public void whenUnsupportedPathServiceRequested_expectNoServiceRequestAndBadRequest(
-      TestContext context) throws Exception {
-    Async async = context.async();
+      VertxTestContext context, Vertx vertx) throws Exception {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
 
@@ -180,24 +165,23 @@ public class HttpClientFacadeTest {
     // then
     result
         .doOnError(error -> {
-          context.assertEquals(UnsupportedDataSourceException.class, error.getClass());
+          Assertions.assertEquals(UnsupportedDataSourceException.class, error.getClass());
           Mockito.verify(mockedWebClient, Mockito.times(0))
               .request(Matchers.any(), Matchers.anyInt(), Matchers.anyString(),
                   Matchers.anyString());
         })
         .subscribe(
-            response -> context.fail("Error should occur!"),
-            error -> async.complete()
+            response -> context.failNow(new Exception("Error should occur!")),
+            error -> context.completeNow()
         );
   }
 
   @Test
-  @KnotxConfiguration("knotx-datasource-http-test.json")
+  @KnotxApplyConfiguration("knotx-datasource-http-test.json")
   public void whenServiceEmptyResponse_expectNoFailure(
-      TestContext context) throws Exception {
-    Async async = context.async();
+      VertxTestContext context, Vertx vertx) throws Exception {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
 
@@ -208,19 +192,19 @@ public class HttpClientFacadeTest {
     // then
     result
         .doOnSuccess(response -> {
-          context.assertEquals(HttpResponseStatus.OK.code(), response.getStatusCode());
-          context.assertEquals(0, Integer.valueOf(response.getHeaders().get("Content-Length")));
+          Assertions.assertEquals(HttpResponseStatus.OK.code(), response.getStatusCode());
+          Assertions.assertEquals((Integer) 0, Integer.valueOf(response.getHeaders().get("Content-Length")));
           Mockito.verify(mockedWebClient, Mockito.times(1))
               .request(HttpMethod.GET, PORT, DOMAIN, "/services/mock/empty.json");
         })
         .subscribe(
-            response -> async.complete(),
-            error -> context.fail(error.getMessage())
+            response -> context.completeNow(),
+            context::failNow
         );
   }
 
-  private WebClient webClient() {
-    return WebClient.create(Vertx.newInstance(vertx.vertx()));
+  private WebClient webClient(Vertx vertx) {
+    return WebClient.create(vertx);
   }
 
   private DataSourceAdapterRequest payloadMessage(String servicePath, ClientRequest request) {

--- a/adapter-http/src/test/java/io/knotx/databridge/http/HttpClientFacadeTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/HttpClientFacadeTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
 
 @ExtendWith(KnotxExtension.class)
 public class HttpClientFacadeTest {
@@ -68,7 +67,7 @@ public class HttpClientFacadeTest {
   public void whenSupportedStaticPathServiceRequested_expectRequestExecutedAndResponseOKWithBody(
       VertxTestContext context, Vertx vertx) throws Exception {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
+    final WebClient mockedWebClient = Mockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
     final JsonObject expectedResponse = new JsonObject(KnotxTestUtils.readText("first-response.json"));
@@ -96,7 +95,7 @@ public class HttpClientFacadeTest {
   public void whenSupportedDynamicPathServiceRequested_expectRequestExecutedAndResponseOKWithBody(
       VertxTestContext context, Vertx vertx) throws Exception {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
+    final WebClient mockedWebClient = Mockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
     final JsonObject expectedResponse = new JsonObject(KnotxTestUtils.readText("first-response.json"));
@@ -125,9 +124,9 @@ public class HttpClientFacadeTest {
   @Test
   @KnotxApplyConfiguration("knotx-datasource-http-test.json")
   public void whenServiceRequestedWithoutPathParam_expectNoServiceRequestAndBadRequest(
-      VertxTestContext context, Vertx vertx) throws Exception {
+      VertxTestContext context, Vertx vertx) {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
+    final WebClient mockedWebClient = Mockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
 
@@ -151,9 +150,9 @@ public class HttpClientFacadeTest {
   @Test
   @KnotxApplyConfiguration("knotx-datasource-http-test.json")
   public void whenUnsupportedPathServiceRequested_expectNoServiceRequestAndBadRequest(
-      VertxTestContext context, Vertx vertx) throws Exception {
+      VertxTestContext context, Vertx vertx) {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
+    final WebClient mockedWebClient = Mockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
 
@@ -179,9 +178,9 @@ public class HttpClientFacadeTest {
   @Test
   @KnotxApplyConfiguration("knotx-datasource-http-test.json")
   public void whenServiceEmptyResponse_expectNoFailure(
-      VertxTestContext context, Vertx vertx) throws Exception {
+      VertxTestContext context, Vertx vertx) {
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient(vertx));
+    final WebClient mockedWebClient = Mockito.spy(webClient(vertx));
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
 

--- a/adapter-http/src/test/java/io/knotx/databridge/http/HttpDataSourceAdapterProxyTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/HttpDataSourceAdapterProxyTest.java
@@ -18,79 +18,72 @@ package io.knotx.databridge.http;
 import io.knotx.dataobjects.AdapterRequest;
 import io.knotx.dataobjects.AdapterResponse;
 import io.knotx.dataobjects.ClientRequest;
-import io.knotx.junit.rule.KnotxConfiguration;
-import io.knotx.junit.rule.TestVertxDeployer;
-import io.knotx.junit.util.FileReader;
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
+import io.knotx.junit5.KnotxTestUtils;
 import io.knotx.reactivex.proxy.AdapterProxy;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.functions.Consumer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.Vertx;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(KnotxExtension.class)
 public class HttpDataSourceAdapterProxyTest {
 
   private final static String ADAPTER_ADDRESS = "knotx.databridge.http";
 
-  //Test Runner Rule of Verts
-  private RunTestOnContext vertx = new RunTestOnContext();
-
-  //Test Runner Rule of Knotx
-  private TestVertxDeployer knotx = new TestVertxDeployer(vertx);
-
-  //Junit Rule, sets up logger, prepares verts, starts verticles according to the config (supplied in annotation of test method)
-  @Rule
-  public RuleChain chain = RuleChain.outerRule(vertx).around(knotx);
-
   @Test
-  @KnotxConfiguration("knotx-datasource-http-test.json")
-  public void callNonExistingService_expectBadRequestResponse(TestContext context) {
-    callAdapterServiceWithAssertions(context, "not/existing/service/address",
-        adapterResponse -> context.assertTrue(adapterResponse.getResponse().getStatusCode()
-            == HttpResponseStatus.INTERNAL_SERVER_ERROR.code()),
-        error -> context.fail(error.getMessage()));
-  }
-
-
-  @Test
-  @KnotxConfiguration("knotx-datasource-http-test.json")
-  public void callExistingService_expectOKResponseWithServiceDataProvidedByService1(
-      TestContext context) throws Exception {
-    final String expected = FileReader.readText("first-response.json");
-
-    callAdapterServiceWithAssertions(context, "/service/mock/first.json",
+  @KnotxApplyConfiguration("knotx-datasource-http-test.json")
+  public void callNonExistingService_expectBadRequestResponse(
+      VertxTestContext context, Vertx vertx) {
+    callAdapterServiceWithAssertions(context, vertx, "not/existing/service/address",
         adapterResponse -> {
-          context.assertTrue(
-              adapterResponse.getResponse().getStatusCode() == HttpResponseStatus.OK.code());
-
-          JsonObject serviceResponse = new JsonObject(
-              adapterResponse.getResponse().getBody().toString());
-          JsonObject expectedResponse = new JsonObject(expected);
-          context.assertEquals(serviceResponse, expectedResponse);
+          context
+              .verify(() -> Assertions.assertEquals(adapterResponse.getResponse().getStatusCode(),
+                  HttpResponseStatus.INTERNAL_SERVER_ERROR.code()));
         },
-        error -> context.fail(error.getMessage()));
+        context::failNow);
   }
 
-  private void callAdapterServiceWithAssertions(TestContext context, String servicePath,
-                                                Consumer<AdapterResponse> onSuccess,
-                                                Consumer<Throwable> onError) {
-    AdapterRequest message = payloadMessage(servicePath);
-    Async async = context.async();
+  @Test
+  @KnotxApplyConfiguration("knotx-datasource-http-test.json")
+  public void callExistingService_expectOKResponseWithServiceDataProvidedByService1(
+      VertxTestContext context, Vertx vertx) throws Exception {
+    final String expected = KnotxTestUtils.readText("first-response.json");
 
-    AdapterProxy service = AdapterProxy.createProxy(new Vertx(vertx.vertx()), ADAPTER_ADDRESS);
+    callAdapterServiceWithAssertions(context, vertx, "/service/mock/first.json",
+        adapterResponse -> {
+          context.verify(() -> {
+            Assertions.assertEquals(adapterResponse.getResponse().getStatusCode(),
+                HttpResponseStatus.OK.code());
+
+            JsonObject serviceResponse = new JsonObject(
+                adapterResponse.getResponse().getBody().toString());
+            JsonObject expectedResponse = new JsonObject(expected);
+
+            Assertions.assertEquals(serviceResponse, expectedResponse);
+          });
+        },
+        context::failNow);
+  }
+
+  private void callAdapterServiceWithAssertions(
+      VertxTestContext context, Vertx vertx,
+      String servicePath,
+      Consumer<AdapterResponse> onSuccess,
+      Consumer<Throwable> onError) {
+    AdapterRequest message = payloadMessage(servicePath);
+
+    AdapterProxy service = AdapterProxy.createProxy(vertx, ADAPTER_ADDRESS);
 
     service.rxProcess(message)
         .doOnSuccess(onSuccess)
         .subscribe(
-            success -> async.complete(),
+            success -> context.completeNow(),
             onError
         );
   }

--- a/adapter-http/src/test/java/io/knotx/databridge/http/HttpDataSourceAdapterProxyTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/HttpDataSourceAdapterProxyTest.java
@@ -72,7 +72,8 @@ public class HttpDataSourceAdapterProxyTest {
   }
 
   private void callAdapterServiceWithAssertions(
-      VertxTestContext context, Vertx vertx,
+      VertxTestContext context,
+      Vertx vertx,
       String servicePath,
       Consumer<AdapterResponse> onSuccess,
       Consumer<Throwable> onError) {

--- a/adapter-http/src/test/java/io/knotx/databridge/http/common/placeholders/UriInfoHelperTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/common/placeholders/UriInfoHelperTest.java
@@ -15,66 +15,57 @@
  */
 package io.knotx.databridge.http.common.placeholders;
 
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.Collection;
-
-@RunWith(Parameterized.class)
 public class UriInfoHelperTest {
 
-  @Parameterized.Parameter
-  public String uri;
-  @Parameterized.Parameter(value = 1)
-  public String path;
-  @Parameterized.Parameter(value = 2)
-  public String selectorString;
-  @Parameterized.Parameter(value = 3)
-  public String extension;
-  @Parameterized.Parameter(value = 4)
-  public String suffix;
-
-  @Parameterized.Parameters(name = "{index}: {0}")
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][]{{"/a/b", "/a/b", null, null, null},
-        {"/a/b.html", "/a/b", null, "html", null},
-        {"/a/b.s1.html", "/a/b", "s1", "html", null},
-        {"/a/b.s1.s2.html", "/a/b", "s1.s2", "html", null},
-        {"/a/b.s1.html/c/d", "/a/b", "s1", "html", "/c/d"},
-        {"/a/b.s1.s2.html/c/d", "/a/b", "s1.s2", "html", "/c/d"},
-        {"/a/b.html/c/d.s.txt", "/a/b", null, "html", "/c/d.s.txt"},
-        {"/a/b.s1.html/c/d.s.txt", "/a/b", "s1", "html", "/c/d.s.txt"},
-        {"/a/b.s1.s2.html/c/d.s.txt", "/a/b", "s1.s2", "html", "/c/d.s.txt"},
-        {"/a/b?q=v", "/a/b", null, null, null},
-        {"/a/b.html?q=v", "/a/b", null, "html", null},
-        {"/a/b.s1.html?q=v", "/a/b", "s1", "html", null},
-        {"/a/b.s1.s2.html?q=v", "/a/b", "s1.s2", "html", null},
-        {"/a/b.s1.html/c/d?q=v", "/a/b", "s1", "html", "/c/d"},
-        {"/a/b.s1.s2.html/c/d?q=v", "/a/b", "s1.s2", "html", "/c/d"},
-        {"/a/b.html/c/d.s.txt?q=v", "/a/b", null, "html", "/c/d.s.txt"},
-        {"/a/b.s1.html/c/d.s.txt?q=v", "/a/b", "s1", "html", "/c/d.s.txt"},
-        {"/a/b.s1.s2.html/c/d.s.txt?q=v", "/a/b", "s1.s2", "html", "/c/d.s.txt"},
-        {"/a/b#f", "/a/b", null, null, null}, {"/a/b.html#f", "/a/b", null, "html", null},
-        {"/a/b.s1.html#f", "/a/b", "s1", "html", null},
-        {"/a/b.s1.s2.html#f", "/a/b", "s1.s2", "html", null},
-        {"/a/b.s1.html/c/d#f", "/a/b", "s1", "html", "/c/d"},
-        {"/a/b.s1.s2.html/c/d#f", "/a/b", "s1.s2", "html", "/c/d"},
-        {"/a/b.html/c/d.s.txt#f", "/a/b", null, "html", "/c/d.s.txt"},
-        {"/a/b.s1.html/c/d.s.txt#f", "/a/b", "s1", "html", "/c/d.s.txt"},
-        {"/a/b.s1.s2.html/c/d.s.txt#f", "/a/b", "s1.s2", "html", "/c/d.s.txt"}});
+  public static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of("/a/b", "/a/b", null, null, null),
+        Arguments.of("/a/b.html", "/a/b", null, "html", null),
+        Arguments.of("/a/b.s1.html", "/a/b", "s1", "html", null),
+        Arguments.of("/a/b.s1.s2.html", "/a/b", "s1.s2", "html", null),
+        Arguments.of("/a/b.s1.html/c/d", "/a/b", "s1", "html", "/c/d"),
+        Arguments.of("/a/b.s1.s2.html/c/d", "/a/b", "s1.s2", "html", "/c/d"),
+        Arguments.of("/a/b.html/c/d.s.txt", "/a/b", null, "html", "/c/d.s.txt"),
+        Arguments.of("/a/b.s1.html/c/d.s.txt", "/a/b", "s1", "html", "/c/d.s.txt"),
+        Arguments.of("/a/b.s1.s2.html/c/d.s.txt", "/a/b", "s1.s2", "html", "/c/d.s.txt"),
+        Arguments.of("/a/b?q=v", "/a/b", null, null, null),
+        Arguments.of("/a/b.html?q=v", "/a/b", null, "html", null),
+        Arguments.of("/a/b.s1.html?q=v", "/a/b", "s1", "html", null),
+        Arguments.of("/a/b.s1.s2.html?q=v", "/a/b", "s1.s2", "html", null),
+        Arguments.of("/a/b.s1.html/c/d?q=v", "/a/b", "s1", "html", "/c/d"),
+        Arguments.of("/a/b.s1.s2.html/c/d?q=v", "/a/b", "s1.s2", "html", "/c/d"),
+        Arguments.of("/a/b.html/c/d.s.txt?q=v", "/a/b", null, "html", "/c/d.s.txt"),
+        Arguments.of("/a/b.s1.html/c/d.s.txt?q=v", "/a/b", "s1", "html", "/c/d.s.txt"),
+        Arguments.of("/a/b.s1.s2.html/c/d.s.txt?q=v", "/a/b", "s1.s2", "html", "/c/d.s.txt"),
+        Arguments.of("/a/b#f", "/a/b", null, null, null),
+        Arguments.of("/a/b.html#f", "/a/b", null, "html", null),
+        Arguments.of("/a/b.s1.html#f", "/a/b", "s1", "html", null),
+        Arguments.of("/a/b.s1.s2.html#f", "/a/b", "s1.s2", "html", null),
+        Arguments.of("/a/b.s1.html/c/d#f", "/a/b", "s1", "html", "/c/d"),
+        Arguments.of("/a/b.s1.s2.html/c/d#f", "/a/b", "s1.s2", "html", "/c/d"),
+        Arguments.of("/a/b.html/c/d.s.txt#f", "/a/b", null, "html", "/c/d.s.txt"),
+        Arguments.of("/a/b.s1.html/c/d.s.txt#f", "/a/b", "s1", "html", "/c/d.s.txt"),
+        Arguments.of("/a/b.s1.s2.html/c/d.s.txt#f", "/a/b", "s1.s2", "html", "/c/d.s.txt")
+        );
   }
 
-  @Test
-  public void getUriInfo_whenGivenUrl_expectProperlyDecomposedUrl() {
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("data")
+  public void getUriInfo_whenGivenUrl_expectProperlyDecomposedUrl(
+      String uri, String path, String selectorString, String extension, String suffix) {
     final SlingUriInfo uriInfo = SlingUriInfoHelper.getUriInfo(uri);
     boolean result = StringUtils.equals(uriInfo.getPath(), path);
     result &= StringUtils.equals(uriInfo.getSelectorString(), selectorString);
     result &= StringUtils.equals(uriInfo.getExtension(), extension);
     result &= StringUtils.equals(uriInfo.getSuffix(), suffix);
-    Assert.assertTrue(result);
+    Assertions.assertTrue(result);
   }
 }

--- a/adapter-http/src/test/java/io/knotx/databridge/http/common/placeholders/UriTransformerPlaceholderTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/common/placeholders/UriTransformerPlaceholderTest.java
@@ -15,10 +15,9 @@
  */
 package io.knotx.databridge.http.common.placeholders;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class UriTransformerPlaceholderTest {
 
@@ -26,6 +25,6 @@ public class UriTransformerPlaceholderTest {
   public void getPlaceholders_whenGivenUrlWithPlaceholders_expectPlaceholdersExtractedInArray() {
     List<String> placeholders =
         UriTransformer.getPlaceholders("/dssds/{first.aa}/dsu/{second}");
-    Assert.assertArrayEquals(placeholders.toArray(), new String[]{"first.aa", "second"});
+    Assertions.assertArrayEquals(placeholders.toArray(), new String[]{"first.aa", "second"});
   }
 }

--- a/adapter-http/src/test/java/io/knotx/databridge/http/common/placeholders/UriTransformerReplaceTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/common/placeholders/UriTransformerReplaceTest.java
@@ -15,102 +15,97 @@
  */
 package io.knotx.databridge.http.common.placeholders;
 
+import java.util.stream.Stream;
+
 import io.knotx.dataobjects.ClientRequest;
 import io.vertx.reactivex.core.MultiMap;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Arrays;
-import java.util.Collection;
-
-@RunWith(Parameterized.class)
 public class UriTransformerReplaceTest {
 
-  @Parameterized.Parameter
-  public String servicePath;
-  @Parameterized.Parameter(value = 1)
-  public String requestedUri;
-  @Parameterized.Parameter(value = 2)
-  public String expectedUri;
-
-  @Parameterized.Parameters(name = "{index}: {0}")
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][]{
+  /**
+   * Data source for following test
+   */
+  public static Stream<Arguments> data() {
+    return Stream.of(
         // SLING URI DECOMPOSITION
         // path
-        {"/path.html?path={slingUri.path}", "/a/b/c/d.s1.s2.html/c/d.s.txt#f",
-            "/path.html?path=/a/b/c/d"},
-        {"/path.html?path={slingUri.path}", "/a/b/c/d.s1.s2.html/c/d.s.txt#f",
-            "/path.html?path=/a/b/c/d"},
+        Arguments.of("/path.html?path={slingUri.path}", "/a/b/c/d.s1.s2.html/c/d.s.txt#f",
+            "/path.html?path=/a/b/c/d"),
+        Arguments.of("/path.html?path={slingUri.path}", "/a/b/c/d.s1.s2.html/c/d.s.txt#f",
+            "/path.html?path=/a/b/c/d"),
         // pathparts
-        {"/path/{slingUri.pathpart[2]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
-            "/path/c.html"},
-        {"/path/{slingUri.pathpart[7]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
-            "/path/.html"},
+        Arguments.of("/path/{slingUri.pathpart[2]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
+            "/path/c.html"),
+        Arguments.of("/path/{slingUri.pathpart[7]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
+            "/path/.html"),
         // extension
-        {"/path/second.html/a.{slingUri.extension}", "/a/b/c/d/e.s1.s2.html/suffix.xml",
-            "/path/second.html/a.html"},
+        Arguments.of("/path/second.html/a.{slingUri.extension}", "/a/b/c/d/e.s1.s2.html/suffix.xml",
+            "/path/second.html/a.html"),
         // selectors
-        {"/selectors.{slingUri.selectorstring}.html", "/a/b.s1.s2.html/c/d.s.txt#f",
-            "/selectors.s1.s2.html"},
-        {"/selectors.{slingUri.selector[0]}.html", "/a/b.s1.s2.html/c/d.s.txt#f",
-            "/selectors.s1.html"},
-        {"/selectors.{slingUri.selector[2]}.html", "/a/b.s1.s2.html/c/d.s.txt#f",
-            "/selectors..html"},
+        Arguments.of("/selectors.{slingUri.selectorstring}.html", "/a/b.s1.s2.html/c/d.s.txt#f",
+            "/selectors.s1.s2.html"),
+        Arguments.of("/selectors.{slingUri.selector[0]}.html", "/a/b.s1.s2.html/c/d.s.txt#f",
+            "/selectors.s1.html"),
+        Arguments.of("/selectors.{slingUri.selector[2]}.html", "/a/b.s1.s2.html/c/d.s.txt#f",
+            "/selectors..html"),
         // suffix
-        {"/suffix.html{slingUri.suffix}", "/a/b/dsds.dd.html/my/nice/suffix.html",
-            "/suffix.html/my/nice/suffix.html"},
+        Arguments.of("/suffix.html{slingUri.suffix}", "/a/b/dsds.dd.html/my/nice/suffix.html",
+            "/suffix.html/my/nice/suffix.html"),
         // REGULAR URI DECOMPOSITION
         // path
-        {"/path.html?path={uri.path}", "/a/b/c/d.s1.s2.html/c/d.s.txt#f",
-            "/path.html?path=/a/b/c/d.s1.s2.html/c/d.s.txt"},
+        Arguments.of("/path.html?path={uri.path}", "/a/b/c/d.s1.s2.html/c/d.s.txt#f",
+            "/path.html?path=/a/b/c/d.s1.s2.html/c/d.s.txt"),
         // pathpart
-        {"/path/{uri.pathpart[5]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
-            "/path/e.s1.s2.html.html"},
+        Arguments.of("/path/{uri.pathpart[5]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
+            "/path/e.s1.s2.html.html"),
         // pathpart
-        {"/path/{uri.pathpart[7]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
-            "/path/d.s.txt.html"},
+        Arguments.of("/path/{uri.pathpart[7]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
+            "/path/d.s.txt.html"),
         // pathpart
-        {"/path/{uri.pathpart[8]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
-            "/path/.html"},
+        Arguments.of("/path/{uri.pathpart[8]}.html", "/a/b/c/d/e.s1.s2.html/c/d.s.txt#f",
+            "/path/.html"),
         // extension
-        {"/path/second.html/a.{uri.extension}", "/a/b.s1.s2.html/c/d.xml",
-            "/path/second.html/a.xml"},
+        Arguments.of("/path/second.html/a.{uri.extension}", "/a/b.s1.s2.html/c/d.xml",
+            "/path/second.html/a.xml"),
         // extension
-        {"/path/second.html/a.{uri.extension}", "/a/b",
-            "/path/second.html/a."},
+        Arguments.of("/path/second.html/a.{uri.extension}", "/a/b",
+            "/path/second.html/a."),
         // param
-        {"/solr/search/{param.q}", "/c/d/s?q=my search is fetched from static getParams()",
-            "/solr/search/core%20%26%20x"},
+        Arguments
+            .of("/solr/search/{param.q}", "/c/d/s?q=my search is fetched from static getParams()",
+                "/solr/search/core%20%26%20x"),
         // headers
-        {"/solr/{header.authorizationId}/", "/c/d/s?q=my action from headers",
-            "/solr/486434684345/"},
+        Arguments.of("/solr/{header.authorizationId}/", "/c/d/s?q=my action from headers",
+            "/solr/486434684345/"),
         // invalid
-        {"/selectors.{invalid}.html", "/a/b.s1.s2.html/c/d.s.txt#f", "/selectors..html"}});
+        Arguments
+            .of("/selectors.{invalid}.html", "/a/b.s1.s2.html/c/d.s.txt#f", "/selectors..html"));
   }
 
   private static MultiMap getHeadersMultiMap() {
-    MultiMap map = MultiMap.caseInsensitiveMultiMap();
-    map.add("authorizationId", "486434684345");
-    return map;
+    return MultiMap.caseInsensitiveMultiMap()
+        .add("authorizationId", "486434684345");
   }
 
   private static MultiMap getParamsMultiMap() {
-    MultiMap map = MultiMap.caseInsensitiveMultiMap();
-    map.add("q", "core & x");
-    map.add("action", "/some/action/path");
-    return map;
+    return MultiMap.caseInsensitiveMultiMap()
+        .add("q", "core & x")
+        .add("action", "/some/action/path");
   }
 
-  @Test
-  public void getServiceUri_whenGivenUriWithPlaceholdersAndMockedRequest_expectPlaceholdersSubstitutedWithValues() {
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("data")
+  public void getServiceUri_whenGivenUriWithPlaceholdersAndMockedRequest_expectPlaceholdersSubstitutedWithValues(
+      String servicePath, String requestedUri, String expectedUri) {
     ClientRequest httpRequest = new ClientRequest().setHeaders(getHeadersMultiMap())
         .setParams(getParamsMultiMap()).setPath(requestedUri);
 
     String finalUri = UriTransformer.resolveServicePath(servicePath, httpRequest);
 
-    Assert.assertEquals(expectedUri, finalUri);
+    Assertions.assertEquals(expectedUri, finalUri);
   }
 }

--- a/adapter-http/src/test/java/io/knotx/databridge/http/common/post/UrlEncodedBodyBuilderTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/common/post/UrlEncodedBodyBuilderTest.java
@@ -15,12 +15,12 @@
  */
 package io.knotx.databridge.http.common.post;
 
-import io.vertx.reactivex.core.MultiMap;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.vertx.reactivex.core.MultiMap;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
 
 public class UrlEncodedBodyBuilderTest {
 

--- a/adapter-http/src/test/java/io/knotx/databridge/http/common/post/UrlEncodedBodyBuilderTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/common/post/UrlEncodedBodyBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package io.knotx.databridge.http.common.post;
 
+import static io.knotx.databridge.http.common.post.UrlEncodedBodyBuilder.encodeBody;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -35,24 +36,24 @@ public class UrlEncodedBodyBuilderTest {
 
   @Test
   public void whenEmptyMultiMap_expectEmptyBodyString() {
-    assertThat(UrlEncodedBodyBuilder.encodeBody(null), equalTo(StringUtils.EMPTY));
-    assertThat(UrlEncodedBodyBuilder.encodeBody(MultiMap.caseInsensitiveMultiMap()),
+    assertThat(encodeBody(null), equalTo(StringUtils.EMPTY));
+    assertThat(encodeBody(MultiMap.caseInsensitiveMultiMap()),
         equalTo(StringUtils.EMPTY));
   }
 
   @Test
   public void whenOneField_expectBodyStringWithOnePair() {
-    assertThat(UrlEncodedBodyBuilder.encodeBody(oneField), equalTo("field1=value%201"));
+    assertThat(encodeBody(oneField), equalTo("field1=value%201"));
   }
 
   @Test
   public void whenTwoFields_expectBodyStringWithTwoPairs() {
-    assertThat(UrlEncodedBodyBuilder.encodeBody(twoFields), equalTo("field1=value1&field2=value%20two"));
+    assertThat(encodeBody(twoFields), equalTo("field1=value1&field2=value%20two"));
   }
 
   @Test
   public void whenThreeFields_expectBodyStringWithThreePairs() {
-    assertThat(UrlEncodedBodyBuilder.encodeBody(threeFields),
+    assertThat(encodeBody(threeFields),
         equalTo("field1=value1&field2=value2&field%20three=value%20three"));
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,11 @@ subprojects {
     compileOnly "io.vertx:vertx-codegen"
 
     // Test dependencies
-    testCompile 'junit:junit'
+    testCompile 'org.junit.jupiter:junit-jupiter-api'
+    testCompile 'org.junit.jupiter:junit-jupiter-engine'
+    testCompile 'org.junit.jupiter:junit-jupiter-params'
+    testCompile 'org.junit.jupiter:junit-jupiter-migrationsupport'
+    testCompile 'org.junit.vintage:junit-vintage-engine'
     testCompile 'com.googlecode.zohhak:zohhak'
     testCompile 'uk.co.datumedge:hamcrest-json'
     testCompile 'org.hamcrest:hamcrest-all'
@@ -71,9 +75,9 @@ subprojects {
 
     testCompileOnly "io.vertx:vertx-codegen"
     testCompile "io.vertx:vertx-config"
-    testCompile 'io.vertx:vertx-unit'
+    testCompile 'io.vertx:vertx-junit5'
     testCompile "io.knotx:knotx-mocks"
-    testCompile group: 'io.knotx', name: 'knotx-core', classifier: 'tests'
+    testCompile 'io.knotx:knotx-junit5:0.0.1-SNAPSHOT'
   }
 
   sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ plugins {
 
 allprojects {
   repositories {
-    mavenLocal()
     jcenter()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://oss.sonatype.org/content/groups/staging/" }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
 
 allprojects {
   repositories {
+    mavenLocal()
     jcenter()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://oss.sonatype.org/content/groups/staging/" }
@@ -52,13 +53,13 @@ subprojects {
   }
 
   dependencies {
-    compile "io.knotx:knotx-core"
+    compile 'io.knotx:knotx-core'
 
-    compile "io.vertx:vertx-core"
-    compile "io.vertx:vertx-service-proxy"
-    compile "io.vertx:vertx-rx-java2"
+    compile 'io.vertx:vertx-core'
+    compile 'io.vertx:vertx-service-proxy'
+    compile 'io.vertx:vertx-rx-java2'
 
-    compileOnly "io.vertx:vertx-codegen"
+    compileOnly 'io.vertx:vertx-codegen'
 
     // Test dependencies
     testCompile 'org.junit.jupiter:junit-jupiter-api'
@@ -66,18 +67,15 @@ subprojects {
     testCompile 'org.junit.jupiter:junit-jupiter-params'
     testCompile 'org.junit.jupiter:junit-jupiter-migrationsupport'
     testCompile 'org.junit.vintage:junit-vintage-engine'
-    testCompile 'com.googlecode.zohhak:zohhak'
     testCompile 'uk.co.datumedge:hamcrest-json'
     testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'org.powermock:powermock-api-mockito'
-    testCompile 'org.powermock:powermock-module-junit4'
-    testCompile "com.github.tomakehurst:wiremock:2.17.0"
+    testCompile 'com.github.tomakehurst:wiremock'
 
-    testCompileOnly "io.vertx:vertx-codegen"
-    testCompile "io.vertx:vertx-config"
+    testCompileOnly 'io.vertx:vertx-codegen'
+    testCompile 'io.vertx:vertx-config'
     testCompile 'io.vertx:vertx-junit5'
-    testCompile "io.knotx:knotx-mocks"
-    testCompile 'io.knotx:knotx-junit5:0.0.1-SNAPSHOT'
+    testCompile 'io.knotx:knotx-mocks'
+    testCompile 'io.knotx:knotx-junit5'
   }
 
   sourceSets {

--- a/core/src/test/java/io/knotx/databridge/core/ServiceCorrectConfigurationTest.java
+++ b/core/src/test/java/io/knotx/databridge/core/ServiceCorrectConfigurationTest.java
@@ -19,25 +19,20 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import io.knotx.junit.util.FileReader;
+import io.knotx.junit5.KnotxTestUtils;
 import io.vertx.core.json.JsonObject;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ServiceCorrectConfigurationTest {
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   private DataBridgeKnotOptions correctConfig;
   private DataSourceDefinition expectedService;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
-    JsonObject config = new JsonObject(FileReader.readText("service-correct.json"));
+    JsonObject config = new JsonObject(KnotxTestUtils.readText("service-correct.json"));
     correctConfig = new DataBridgeKnotOptions(config);
     expectedService = createMockedService("first-service", "knotx.core-adapter",
         "{\"path\":\"/service/mock/first.json\"}", "first");

--- a/core/src/test/java/io/knotx/databridge/core/datasource/DataSourceEntryTest.java
+++ b/core/src/test/java/io/knotx/databridge/core/datasource/DataSourceEntryTest.java
@@ -19,11 +19,11 @@ package io.knotx.databridge.core.datasource;
 import io.knotx.databridge.core.DataBridgeKnotOptions;
 import io.knotx.databridge.core.attribute.DataSourceAttribute;
 import io.knotx.databridge.core.attribute.DataSourceAttribute.AtributeType;
-import io.knotx.junit.util.FileReader;
+import io.knotx.junit5.KnotxTestUtils;
 import io.vertx.core.json.JsonObject;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class DataSourceEntryTest {
 
@@ -33,13 +33,13 @@ public class DataSourceEntryTest {
 
   private static DataBridgeKnotOptions CONFIG_NO_DEFAULT_PARAMS;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     CONFIG_WITH_DEFAULT_PARAMS = new DataBridgeKnotOptions(
-        new JsonObject(FileReader.readText("service-correct.json"))
+        new JsonObject(KnotxTestUtils.readText("service-correct.json"))
     );
     CONFIG_NO_DEFAULT_PARAMS = new DataBridgeKnotOptions(
-        new JsonObject(FileReader.readText("service-correct-no-params.json"))
+        new JsonObject(KnotxTestUtils.readText("service-correct-no-params.json"))
     );
   }
 
@@ -52,7 +52,7 @@ public class DataSourceEntryTest {
             .withValue("{\"path\":\"first-service\"}"));
     serviceEntry
         .mergeParams(CONFIG_WITH_DEFAULT_PARAMS.getDataDefinitions().iterator().next().getParams());
-    Assert.assertEquals("first-service", serviceEntry.getParams().getString("path"));
+    Assertions.assertEquals("first-service", serviceEntry.getParams().getString("path"));
   }
 
   @Test
@@ -63,7 +63,7 @@ public class DataSourceEntryTest {
         DataSourceAttribute.of(AtributeType.PARAMS).withNamespace(NAMESPACE).withValue("{}"));
     serviceEntry
         .mergeParams(CONFIG_WITH_DEFAULT_PARAMS.getDataDefinitions().iterator().next().getParams());
-    Assert.assertEquals("/service/mock/first.json", serviceEntry.getParams().getString("path"));
+    Assertions.assertEquals("/service/mock/first.json", serviceEntry.getParams().getString("path"));
   }
 
   @Test
@@ -75,8 +75,8 @@ public class DataSourceEntryTest {
             .withValue("{\"name\":\"first-service-name\"}"));
     serviceEntry
         .mergeParams(CONFIG_WITH_DEFAULT_PARAMS.getDataDefinitions().iterator().next().getParams());
-    Assert.assertEquals("/service/mock/first.json", serviceEntry.getParams().getString("path"));
-    Assert.assertEquals("first-service-name", serviceEntry.getParams().getString("name"));
+    Assertions.assertEquals("/service/mock/first.json", serviceEntry.getParams().getString("path"));
+    Assertions.assertEquals("first-service-name", serviceEntry.getParams().getString("name"));
   }
 
   @Test
@@ -88,6 +88,6 @@ public class DataSourceEntryTest {
             .withValue("{\"path\":\"some-other-service.json\"}"));
     serviceEntry
         .mergeParams(CONFIG_NO_DEFAULT_PARAMS.getDataDefinitions().iterator().next().getParams());
-    Assert.assertEquals("some-other-service.json", serviceEntry.getParams().getString("path"));
+    Assertions.assertEquals("some-other-service.json", serviceEntry.getParams().getString("path"));
   }
 }

--- a/core/src/test/java/io/knotx/databridge/core/impl/FragmentContextTest.java
+++ b/core/src/test/java/io/knotx/databridge/core/impl/FragmentContextTest.java
@@ -19,55 +19,56 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
-import org.junit.runner.RunWith;
-
-import com.googlecode.zohhak.api.Configure;
-import com.googlecode.zohhak.api.TestWith;
-import com.googlecode.zohhak.api.runners.ZohhakRunner;
-
 import io.knotx.databridge.core.datasource.DataSourceEntry;
 import io.knotx.dataobjects.Fragment;
-import io.knotx.junit.coercers.KnotxCoercers;
+import io.knotx.junit5.KnotxArgumentConverter;
 import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.CsvSource;
 
-@RunWith(ZohhakRunner.class)
-@Configure(separator = ";", coercers = KnotxCoercers.class)
 public class FragmentContextTest {
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(value = {
       "snippet_one_service_no_params.txt;{}",
       "snippet_one_service_invalid_params_bound.txt;{}",
       "snippet_one_service_one_param.txt;{\"path\":\"/overridden/path\"}",
       "snippet_one_service_many_params.txt;{\"path\":\"/overridden/path\",\"anotherParam\":\"someValue\"}"
-  })
+  }, delimiter = ';')
   public void from_whenFragmentContainsOneService_expectFragmentContextWithExtractedParamsParams(
-      Fragment fragment, String expectedParameters) throws Exception {
+      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment,
+      String expectedParameters) throws Exception {
 
     final FragmentContext fragmentContext = FragmentContext.from(fragment);
     final DataSourceEntry serviceEntry = fragmentContext.services.get(0);
     assertThat(serviceEntry.getParams().toString(), sameJSONAs(expectedParameters));
   }
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(value = {
       "snippet_one_service_no_params.txt;1",
       "snippet_one_service_one_param.txt;1",
       "snippet_one_service_many_params.txt;1",
       "snippet_two_services.txt;2",
       "snippet_five_services.txt;5"
-  })
+  }, delimiter = ';')
   public void from_whenFragmentContainsServices_expectFragmentContextWithProperNumberOfServicesExtracted(
-      Fragment fragment, int numberOfExpectedServices) throws Exception {
+      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment,
+      int numberOfExpectedServices) throws Exception {
 
     final FragmentContext fragmentContext = FragmentContext.from(fragment);
     assertThat(fragmentContext.services.size(), is(numberOfExpectedServices));
   }
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(value = {
       "snippet_two_services_with_params.txt;{\"first\":{\"first-service-key\":\"first-service-value\"},\"second\":{\"second-service-key\":\"second-service-value\"}}",
       "snippet_four_services_with_params_and_extra_param.txt;{\"a\":{\"a\":\"a\"},\"b\":{\"b\":\"b\"},\"c\":{\"c\":\"c\"},\"d\":{\"d\":\"d\"}}"
-  })
+  }, delimiter = ';')
   public void from_whenFragmentContainsServices_expectProperlyAssignedParams(
-      Fragment fragment, JsonObject parameters) throws Exception {
+      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment,
+      @ConvertWith(KnotxArgumentConverter.class) JsonObject parameters) throws Exception {
 
     final FragmentContext fragmentContext = FragmentContext.from(fragment);
     fragmentContext.services.forEach(serviceEntry ->


### PR DESCRIPTION
Ported unit and integration tests to JUnit 5. General logic of the tests was not changed, as the main priority was to make them work under v5 and not review of tests themselves.

Verified to be working correctly locally. Travis CI currently *will fail*, since Knotx/knotx-dependencies#2 and Knotx/knotx-junit5#1 need to be merged and published beforehand.

Part of Cognifide/knotx#417.