### PR TITLE
Tests: use common response handler methods from knotx-junit5

### DIFF
--- a/core/src/test/java/io/knotx/databridge/core/ServiceCorrectConfigurationTest.java
+++ b/core/src/test/java/io/knotx/databridge/core/ServiceCorrectConfigurationTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import io.knotx.junit5.KnotxTestUtils;
+import io.knotx.junit5.util.FileReader;
 import io.vertx.core.json.JsonObject;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +32,7 @@ public class ServiceCorrectConfigurationTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    JsonObject config = new JsonObject(KnotxTestUtils.readText("service-correct.json"));
+    JsonObject config = new JsonObject(FileReader.readText("service-correct.json"));
     correctConfig = new DataBridgeKnotOptions(config);
     expectedService = createMockedService("first-service", "knotx.core-adapter",
         "{\"path\":\"/service/mock/first.json\"}", "first");

--- a/core/src/test/java/io/knotx/databridge/core/datasource/DataSourceEntryTest.java
+++ b/core/src/test/java/io/knotx/databridge/core/datasource/DataSourceEntryTest.java
@@ -19,7 +19,7 @@ package io.knotx.databridge.core.datasource;
 import io.knotx.databridge.core.DataBridgeKnotOptions;
 import io.knotx.databridge.core.attribute.DataSourceAttribute;
 import io.knotx.databridge.core.attribute.DataSourceAttribute.AtributeType;
-import io.knotx.junit5.KnotxTestUtils;
+import io.knotx.junit5.util.FileReader;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,10 +36,10 @@ public class DataSourceEntryTest {
   @BeforeAll
   public static void setUp() throws Exception {
     CONFIG_WITH_DEFAULT_PARAMS = new DataBridgeKnotOptions(
-        new JsonObject(KnotxTestUtils.readText("service-correct.json"))
+        new JsonObject(FileReader.readText("service-correct.json"))
     );
     CONFIG_NO_DEFAULT_PARAMS = new DataBridgeKnotOptions(
-        new JsonObject(KnotxTestUtils.readText("service-correct-no-params.json"))
+        new JsonObject(FileReader.readText("service-correct-no-params.json"))
     );
   }
 


### PR DESCRIPTION
Will also allow to remove KnotxTestUtils from knotx-junit5 after pushing similar changes to knotx-core.