### PR TITLE
Set development version to 1.4.0-SNAPSHOT

### DIFF
--- a/adapter-http/src/main/java/io/knotx/databridge/http/common/configuration/HttpDataSourceSettings.java
+++ b/adapter-http/src/main/java/io/knotx/databridge/http/common/configuration/HttpDataSourceSettings.java
@@ -108,6 +108,7 @@ public class HttpDataSourceSettings {
   /**
    * Set the {@code domain} of the external service
    *
+   * @param domain - domain of the external service
    * @return a reference to this, so the API can be used fluently
    */
   public HttpDataSourceSettings setDomain(String domain) {
@@ -164,6 +165,7 @@ public class HttpDataSourceSettings {
   /**
    * Set the additional request query parameters to be send in each request
    *
+   * @param queryParams - JSON Object specifying query param
    * @return a reference to this, so the API can be used fluently
    */
   public HttpDataSourceSettings setQueryParams(JsonObject queryParams) {
@@ -181,6 +183,7 @@ public class HttpDataSourceSettings {
   /**
    * Set the additional request headers (and values) to be send in each request
    *
+   * @param additionalHeaders - JSON Object specifying additional header
    * @return a reference to this, so the API can be used fluently
    */
   public HttpDataSourceSettings setAdditionalHeaders(JsonObject additionalHeaders) {

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,12 @@
  */
 plugins {
   id 'io.spring.dependency-management' version '1.0.5.RELEASE' apply false
+  id 'maven'
 }
 
 allprojects {
   repositories {
+    mavenLocal()
     jcenter()
     maven { url 'https://plugins.gradle.org/m2/' }
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
@@ -44,7 +46,7 @@ subprojects { subproject ->
 
   dependencyManagement {
     imports {
-      mavenBom 'io.knotx:knotx-dependencies:1.3.1-SNAPSHOT'
+      mavenBom 'io.knotx:knotx-dependencies:1.4.0-SNAPSHOT'
     }
   }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,6 +23,7 @@ configurations {
 
 dependencies {
   compile project(':knotx-databridge-api')
+  testCompile group: 'io.knotx', name: 'knotx-core', version: '1.4.0-SNAPSHOT', classifier: 'tests'
   testResources sourceSets.test.output
 }
 

--- a/core/src/test/java/io/knotx/databridge/core/impl/FragmentContextTest.java
+++ b/core/src/test/java/io/knotx/databridge/core/impl/FragmentContextTest.java
@@ -21,6 +21,7 @@ import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 import io.knotx.databridge.core.datasource.DataSourceEntry;
 import io.knotx.dataobjects.Fragment;
+import io.knotx.junit.converter.FragmentArgumentConverter;
 import io.knotx.junit5.KnotxArgumentConverter;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,7 +38,7 @@ public class FragmentContextTest {
       "snippet_one_service_many_params.txt;{\"path\":\"/overridden/path\",\"anotherParam\":\"someValue\"}"
   }, delimiter = ';')
   public void from_whenFragmentContainsOneService_expectFragmentContextWithExtractedParamsParams(
-      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment,
+      @ConvertWith(FragmentArgumentConverter.class) Fragment fragment,
       String expectedParameters) throws Exception {
 
     final FragmentContext fragmentContext = FragmentContext.from(fragment);
@@ -55,7 +56,7 @@ public class FragmentContextTest {
       "snippet_five_services_custom_prefix;5"
   }, delimiter = ';')
   public void from_whenFragmentContainsServices_expectFragmentContextWithProperNumberOfServicesExtracted(
-      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment,
+      @ConvertWith(FragmentArgumentConverter.class) Fragment fragment,
       int numberOfExpectedServices) throws Exception {
 
     final FragmentContext fragmentContext = FragmentContext.from(fragment);
@@ -68,7 +69,7 @@ public class FragmentContextTest {
       "snippet_four_services_with_params_and_extra_param.txt;{\"a\":{\"a\":\"a\"},\"b\":{\"b\":\"b\"},\"c\":{\"c\":\"c\"},\"d\":{\"d\":\"d\"}}"
   }, delimiter = ';')
   public void from_whenFragmentContainsServices_expectProperlyAssignedParams(
-      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment,
+      @ConvertWith(FragmentArgumentConverter.class) Fragment fragment,
       @ConvertWith(KnotxArgumentConverter.class) JsonObject parameters) throws Exception {
 
     final FragmentContext fragmentContext = FragmentContext.from(fragment);

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 org.gradle.daemon=false
 org.gradle.parallel=false
 
-version=1.3.1-SNAPSHOT
+version=1.4.0-SNAPSHOT


### PR DESCRIPTION
Set development version to 1.4.0-SNAPSHOT and resolved cyclic dependency between core and junit5 modules, see [this `knotx-dependencies` PR](https://github.com/Knotx/knotx-dependencies/pull/11) and [this `knotx-junit5` PR](https://github.com/Knotx/knotx-junit5/pull/22) first.