### PR TITLE
Fallback-aware failure handling for data-bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-data-bridge` will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-37](https://github.com/Knotx/knotx-data-bridge/pull/37) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) in data bridge
 
 ## 1.4.0
 Initial open source release.

--- a/core/src/main/java/io/knotx/databridge/core/DataBridgeKnotProxy.java
+++ b/core/src/main/java/io/knotx/databridge/core/DataBridgeKnotProxy.java
@@ -36,7 +36,7 @@ public class DataBridgeKnotProxy extends AbstractKnotProxy {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DataBridgeKnotProxy.class);
 
-  private static final String SUPPORTED_FRAGMENT_ID = "databridge";
+  public static final String SUPPORTED_FRAGMENT_ID = "databridge";
 
   private FragmentProcessor snippetProcessor;
 
@@ -49,7 +49,7 @@ public class DataBridgeKnotProxy extends AbstractKnotProxy {
     return Optional.ofNullable(knotContext.getFragments())
         .map(fragments ->
             Observable.fromIterable(fragments)
-                .filter(fragment -> fragment.knots().contains(SUPPORTED_FRAGMENT_ID))
+                .filter(this::shouldProcess)
                 .doOnNext(this::traceFragment)
                 .map(FragmentContext::from)
                 .flatMapSingle(

--- a/core/src/main/java/io/knotx/databridge/core/impl/FragmentProcessor.java
+++ b/core/src/main/java/io/knotx/databridge/core/impl/FragmentProcessor.java
@@ -15,6 +15,9 @@
  */
 package io.knotx.databridge.core.impl;
 
+import io.knotx.databridge.core.DataBridgeKnotProxy;
+import io.knotx.dataobjects.Fragment;
+import io.knotx.dataobjects.KnotTaskStatus;
 import java.util.concurrent.ExecutionException;
 
 import io.knotx.databridge.core.DataBridgeKnotOptions;
@@ -39,7 +42,7 @@ public class FragmentProcessor {
   }
 
   public Single<FragmentContext> processSnippet(final FragmentContext fragmentContext,
-      KnotContext request) {
+                                                KnotContext request) {
     if (LOGGER.isTraceEnabled()) {
       LOGGER.trace("Processing Handlebars snippet {}", fragmentContext.fragment());
     }
@@ -49,9 +52,23 @@ public class FragmentProcessor {
         .doOnNext(this::traceService)
         .flatMap(serviceEntry ->
             fetchServiceData(serviceEntry, request).toObservable()
-                .map(serviceEntry::getResultWithNamespaceAsKey))
+                .map(serviceEntry::getResultWithNamespaceAsKey)
+                .doOnError(e -> storeErrorInFragment(fragmentContext.fragment(), e, serviceEntry.getName()))
+        )
         .reduce(new JsonObject(), JsonObject::mergeIn)
-        .map(results -> applyData(fragmentContext, results));
+        .map(results -> applyData(fragmentContext, results))
+        .onErrorReturn(e -> {
+          LOGGER.error("Fragment processing failed. Cause:{}\nRequest:\n{}\nFragmentContext:\n{}\n", e.getMessage(), request.getClientRequest(), fragmentContext);
+          fragmentContext.fragment().failure(DataBridgeKnotProxy.SUPPORTED_FRAGMENT_ID, e);
+          if (!fragmentContext.fragment().fallback().isPresent()) {
+            if (e instanceof RuntimeException) {
+              throw (RuntimeException) e;
+            } else {
+              throw new IllegalStateException(e);
+            }
+          }
+          return fragmentContext;
+        });
   }
 
   private Single<JsonObject> fetchServiceData(DataSourceEntry service, KnotContext request) {
@@ -81,6 +98,11 @@ public class FragmentProcessor {
       LOGGER.debug("Found service call definition: {} {}", serviceEntry.getAddress(),
           serviceEntry.getParams());
     }
+  }
+
+  private void storeErrorInFragment(Fragment fragment, Throwable e, String name) {
+    LOGGER.error("Data Bridge service {} failed. Cause: {}", name, e.getMessage());
+    fragment.failure(DataBridgeKnotProxy.SUPPORTED_FRAGMENT_ID, e);
   }
 
 }

--- a/core/src/main/java/io/knotx/databridge/core/impl/FragmentProcessor.java
+++ b/core/src/main/java/io/knotx/databridge/core/impl/FragmentProcessor.java
@@ -17,8 +17,7 @@ package io.knotx.databridge.core.impl;
 
 import io.knotx.databridge.core.DataBridgeKnotProxy;
 import io.knotx.dataobjects.Fragment;
-import io.knotx.dataobjects.KnotTaskStatus;
-import io.knotx.exceptions.FragmentExecutionException;
+import io.knotx.exceptions.FragmentProcessingException;
 import java.util.concurrent.ExecutionException;
 
 import io.knotx.databridge.core.DataBridgeKnotOptions;
@@ -101,7 +100,7 @@ public class FragmentProcessor {
     if (fragmentContext.fragment().fallback().isPresent()) {
       return fragmentContext;
     } else {
-      throw new FragmentExecutionException(String.format("Fragment processing failed in %s", DataBridgeKnotProxy.SUPPORTED_FRAGMENT_ID), t);
+      throw new FragmentProcessingException(String.format("Fragment processing failed in %s", DataBridgeKnotProxy.SUPPORTED_FRAGMENT_ID), t);
     }
   }
 


### PR DESCRIPTION
Implementation of new knotx feature (fragment processing faiilure handling) within data bridge

## Description
New failure handling feature was implemented in  https://github.com/Cognifide/knotx/issues/466
This PR allows data bridge to take advantage of the new approach and handle data bridge failures in a more robust way. 

## Motivation and Context
See core feature documentation

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
Requires https://github.com/Cognifide/knotx/issues/466
Integration tests to be added to knotx-stack project

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
