### PR TITLE
Adapt to Knot.x JUnit 5 API changes: annotations rename, parallel tests execution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,14 +237,6 @@ When found a placeholder within the `path` parameter it will be replaced with a 
 Space character is substituted by %20 instead of +.
 Slash character / remains as it is.
 
-## Building
-To build this module use gradle with following settings:
-```gradle
- org.gradle.daemon=false
- org.gradle.parallel=false
-```
-This is temporary and will be changed as soon as tests that runs on the same ports will be fixed.
-
 ## Community
 Knot.x gives one communication channel that is described [here](https://github.com/Cognifide/knotx#community).
 

--- a/adapter-http/src/test/java/io/knotx/databridge/http/HttpClientFacadeTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/HttpClientFacadeTest.java
@@ -56,7 +56,7 @@ import org.mockito.quality.Strictness;
 @ExtendWith(VertxExtension.class)
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.WARN)
-public class HttpClientFacadeTest {
+class HttpClientFacadeTest {
 
   // Configuration
   private static final String DOMAIN = "localhost";
@@ -68,7 +68,7 @@ public class HttpClientFacadeTest {
       .singletonList(Pattern.compile("X-test*"));
 
   @Test
-  public void whenSupportedStaticPathServiceRequested_expectRequestExecutedAndResponseOKWithBody(
+  void whenSupportedStaticPathServiceRequested_expectRequestExecutedAndResponseOKWithBody(
       VertxTestContext context, Vertx vertx) throws Exception {
     // given
     final WebClient mockedWebClient = Mockito.spy(webClient(vertx));
@@ -93,7 +93,7 @@ public class HttpClientFacadeTest {
   }
 
   @Test
-  public void whenSupportedDynamicPathServiceRequested_expectRequestExecutedAndResponseOKWithBody(
+  void whenSupportedDynamicPathServiceRequested_expectRequestExecutedAndResponseOKWithBody(
       VertxTestContext context, Vertx vertx) throws Exception {
     // given
     final JsonObject expectedResponse = new JsonObject(FileReader.readText("service/mock/response.json"));
@@ -121,7 +121,7 @@ public class HttpClientFacadeTest {
   }
 
   @Test
-  public void whenServiceRequestedWithoutPathParam_expectNoServiceRequestAndBadRequest(
+  void whenServiceRequestedWithoutPathParam_expectNoServiceRequestAndBadRequest(
       VertxTestContext context, Vertx vertx) {
     // given
     final WebClient mockedWebClient = Mockito.spy(webClient(vertx));
@@ -143,7 +143,7 @@ public class HttpClientFacadeTest {
   }
 
   @Test
-  public void whenUnsupportedPathServiceRequested_expectNoServiceRequestAndBadRequest(
+  void whenUnsupportedPathServiceRequested_expectNoServiceRequestAndBadRequest(
       VertxTestContext context, Vertx vertx) {
     // given
     final WebClient mockedWebClient = Mockito.spy(webClient(vertx));
@@ -165,7 +165,7 @@ public class HttpClientFacadeTest {
   }
 
   @Test
-  public void whenServiceEmptyResponse_expectNoFailure(VertxTestContext context, Vertx vertx) {
+  void whenServiceEmptyResponse_expectNoFailure(VertxTestContext context, Vertx vertx) {
     // given
     final WireMockServer wireMockServer = mockEndpoint(HttpResponseStatus.OK.code(),
         "/services/mock/empty.json", "");

--- a/adapter-http/src/test/java/io/knotx/databridge/http/HttpDataSourceAdapterProxyTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/HttpDataSourceAdapterProxyTest.java
@@ -58,7 +58,7 @@ class HttpDataSourceAdapterProxyTest {
   @Test
   @KnotxApplyConfiguration("httpAdapterStack.conf")
   void callExistingService_expectOKResponseWithServiceDataProvidedByService1(
-      @ClasspathResourcesMockServer(port = 3000) WireMockServer mockService,
+      @ClasspathResourcesMockServer WireMockServer mockService,
       VertxTestContext context, Vertx vertx)
       throws Exception {
     final String expected = FileReader.readText("service/mock/response.json");

--- a/adapter-http/src/test/java/io/knotx/databridge/http/HttpDataSourceAdapterProxyTest.java
+++ b/adapter-http/src/test/java/io/knotx/databridge/http/HttpDataSourceAdapterProxyTest.java
@@ -26,7 +26,7 @@ import io.knotx.databridge.api.DataSourceAdapterResponse;
 import io.knotx.junit5.KnotxApplyConfiguration;
 import io.knotx.junit5.KnotxExtension;
 import io.knotx.junit5.util.FileReader;
-import io.knotx.junit5.wiremock.KnotxWiremock;
+import io.knotx.junit5.wiremock.ClasspathResourcesMockServer;
 import io.knotx.junit5.wiremock.KnotxWiremockExtension;
 import io.knotx.reactivex.databridge.api.DataSourceAdapterProxy;
 import io.knotx.server.api.context.ClientRequest;
@@ -41,26 +41,25 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(KnotxExtension.class)
-public class HttpDataSourceAdapterProxyTest {
+class HttpDataSourceAdapterProxyTest {
 
   private final static String ADAPTER_ADDRESS = "knotx.bridge.datasource.http";
 
   @Test
   @KnotxApplyConfiguration("httpAdapterStack.conf")
-  public void callNonExistingService_expectBadRequestResponse(VertxTestContext context,
+  void callNonExistingService_expectBadRequestResponse(VertxTestContext context,
       Vertx vertx) {
     callAdapterServiceWithAssertions(context, vertx, "not/existing/service/address",
-        adapterResponse -> {
-          Assertions.assertEquals(adapterResponse.getResponse().getStatusCode(),
-              HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
-        }
+        adapterResponse -> Assertions.assertEquals(adapterResponse.getResponse().getStatusCode(),
+            HttpResponseStatus.INTERNAL_SERVER_ERROR.code())
     );
   }
 
   @Test
   @KnotxApplyConfiguration("httpAdapterStack.conf")
-  public void callExistingService_expectOKResponseWithServiceDataProvidedByService1(
-      @KnotxWiremock(port = 3000) WireMockServer mockService, VertxTestContext context, Vertx vertx)
+  void callExistingService_expectOKResponseWithServiceDataProvidedByService1(
+      @ClasspathResourcesMockServer(port = 3000) WireMockServer mockService,
+      VertxTestContext context, Vertx vertx)
       throws Exception {
     final String expected = FileReader.readText("service/mock/response.json");
 
@@ -72,7 +71,8 @@ public class HttpDataSourceAdapterProxyTest {
 
     callAdapterServiceWithAssertions(context, vertx, "/service/mock/response.json",
         adapterResponse -> {
-          Assertions.assertEquals(HttpResponseStatus.OK.code(), adapterResponse.getResponse().getStatusCode());
+          Assertions.assertEquals(HttpResponseStatus.OK.code(),
+              adapterResponse.getResponse().getStatusCode());
 
           JsonObject serviceResponse = new JsonObject(
               adapterResponse.getResponse().getBody().toString());

--- a/adapter-http/src/test/resources/httpAdapterStack.conf
+++ b/adapter-http/src/test/resources/httpAdapterStack.conf
@@ -1,3 +1,7 @@
+########### Knot.x JUnit5 config ###########
+# classpath resource mock service with random port
+test.wiremock.mockService.port = 0
+
 ########### Modules to start ###########
 modules = [
   "dataSourceHttp=io.knotx.databridge.http.HttpDataSourceAdapter"
@@ -30,7 +34,7 @@ config.dataSourceHttp {
       {
         path = "/service/mock/.*"
         domain = localhost
-        port = 3000
+        port = ${test.wiremock.mockService.port}
         allowedRequestHeaders = [
           "Accept*",
           "Content*",

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ subprojects { subproject ->
 
   tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
+    options.compilerArgs << '-parameters'
     options.compilerArgs << '-Xlint:deprecation'
     options.incremental = true
   }

--- a/conf/dataBridgeStack.conf
+++ b/conf/dataBridgeStack.conf
@@ -1,3 +1,7 @@
+########### Knot.x JUnit5 config ###########
+# classpath resource mock service with random port
+test.wiremock.mockService.port = 0
+
 ########### Modules to start ###########
 modules = [
   "dataBridge=io.knotx.databridge.core.DataBridgeKnot"
@@ -26,12 +30,5 @@ config.dataBridge {
 config.dataSourceHttp {
   options.config {
     include required(classpath("dataBridgeSourceHttp.conf"))
-  }
-}
-
-########### WireMock config ###########
-test.wiremock {
-  mockService {
-    port = 4000
   }
 }

--- a/core/src/test/java/io/knotx/databridge/core/impl/DataBridgeSnippetTest.java
+++ b/core/src/test/java/io/knotx/databridge/core/impl/DataBridgeSnippetTest.java
@@ -22,15 +22,13 @@ import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 import io.knotx.databridge.core.datasource.DataSourceEntry;
 import io.knotx.engine.api.FragmentEvent;
 import io.knotx.fragment.Fragment;
-import io.knotx.junit5.KnotxArgumentConverter;
 import io.knotx.junit5.util.FileReader;
 import io.vertx.core.json.JsonObject;
 import java.io.IOException;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.CsvSource;
 
-public class DataBridgeSnippetTest {
+class DataBridgeSnippetTest {
 
   @ParameterizedTest
   @CsvSource(value = {
@@ -39,7 +37,7 @@ public class DataBridgeSnippetTest {
       "fragment/one_service_one_param.json;{\"path\":\"/overridden/path\"}",
       "fragment/one_service_many_params.json;{\"path\":\"/overridden/path\",\"anotherParam\":\"someValue\"}"
   }, delimiter = ';')
-  public void from_whenFragmentContainsOneService_expectFragmentContextWithExtractedParams(
+  void from_whenFragmentContainsOneService_expectFragmentContextWithExtractedParams(
       String fragmentContentFile,
       String expectedParameters) throws Exception {
 
@@ -57,7 +55,7 @@ public class DataBridgeSnippetTest {
       "fragment/two_services.json;2",
       "fragment/five_services.json;5"
   }, delimiter = ';')
-  public void from_whenFragmentContainsServices_expectFragmentContextWithProperNumberOfServicesExtracted(
+  void from_whenFragmentContainsServices_expectFragmentContextWithProperNumberOfServicesExtracted(
       String fragmentContentFile,
       int numberOfExpectedServices) throws Exception {
     FragmentEvent fragment = fromJsonFile(fragmentContentFile);
@@ -71,15 +69,16 @@ public class DataBridgeSnippetTest {
       "fragment/two_services_with_params.json;{\"first\":{\"first-service-key\":\"first-service-value\"},\"second\":{\"second-service-key\":\"second-service-value\"}}",
       "fragment/four_services_with_params_and_extra_param.json;{\"a\":{\"a\":\"a\"},\"b\":{\"b\":\"b\"},\"c\":{\"c\":\"c\"},\"d\":{\"d\":\"d\"}}"
   }, delimiter = ';')
-  public void from_whenFragmentContainsServices_expectProperlyAssignedParams(
+  void from_whenFragmentContainsServices_expectProperlyAssignedParams(
       String fragmentContentFile,
-      @ConvertWith(KnotxArgumentConverter.class) JsonObject parameters) throws Exception {
+      String parameters) throws Exception {
     FragmentEvent fragment = fromJsonFile(fragmentContentFile);
 
     final DataBridgeSnippet dataBridgeFragmentContext = DataBridgeSnippet.from(fragment);
     dataBridgeFragmentContext.services.forEach(serviceEntry ->
         assertThat(serviceEntry.getParams().toString(),
-            sameJSONAs(parameters.getJsonObject(serviceEntry.getNamespace()).toString())
+            sameJSONAs(
+                new JsonObject(parameters).getJsonObject(serviceEntry.getNamespace()).toString())
         )
     );
   }

--- a/it-test/src/test/java/io/knotx/databridge/test/integration/DataBridgeIntegrationTest.java
+++ b/it-test/src/test/java/io/knotx/databridge/test/integration/DataBridgeIntegrationTest.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class DataBridgeIntegrationTest {
 
   @ClasspathResourcesMockServer
-  protected WireMockServer mockService;
+  private WireMockServer mockService;
 
   @Test
   @DisplayName("Expect a success status when HTTP service responds with HTTP 200.")

--- a/it-test/src/test/java/io/knotx/databridge/test/integration/DataBridgeIntegrationTest.java
+++ b/it-test/src/test/java/io/knotx/databridge/test/integration/DataBridgeIntegrationTest.java
@@ -32,7 +32,7 @@ import io.knotx.fragment.Fragment;
 import io.knotx.junit5.KnotxApplyConfiguration;
 import io.knotx.junit5.KnotxExtension;
 import io.knotx.junit5.util.FileReader;
-import io.knotx.junit5.wiremock.KnotxWiremock;
+import io.knotx.junit5.wiremock.ClasspathResourcesMockServer;
 import io.knotx.junit5.wiremock.KnotxWiremockExtension;
 import io.knotx.server.api.context.ClientRequest;
 import io.reactivex.Single;
@@ -48,15 +48,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(KnotxExtension.class)
-public class DataBridgeIntegrationTest {
+class DataBridgeIntegrationTest {
 
-  @KnotxWiremock
+  @ClasspathResourcesMockServer
   protected WireMockServer mockService;
 
   @Test
   @DisplayName("Expect a success status when HTTP service responds with HTTP 200.")
   @KnotxApplyConfiguration("dataBridgeStack.conf")
-  public void callDataBridge_validSnippetFragmentsContextResult(VertxTestContext context,
+  void callDataBridge_validSnippetFragmentsContextResult(VertxTestContext context,
       Vertx vertx) throws IOException {
 
     mockDataSource();
@@ -76,7 +76,7 @@ public class DataBridgeIntegrationTest {
   @Test
   @DisplayName("Expect a response in the namespace when HTTP service responds with HTTP 200.")
   @KnotxApplyConfiguration("dataBridgeStack.conf")
-  public void callDataBridgeWithNamespacedValidDS(VertxTestContext context,
+  void callDataBridgeWithNamespacedValidDS(VertxTestContext context,
       Vertx vertx) throws IOException {
 
     mockDataSource();
@@ -95,7 +95,7 @@ public class DataBridgeIntegrationTest {
   @Test
   @DisplayName("Expect an error when HTTP service responds with error.")
   @KnotxApplyConfiguration("dataBridgeStack.conf")
-  public void callDataBridge_invalidSnippetFragmentsContextResult(
+  void callDataBridge_invalidSnippetFragmentsContextResult(
       VertxTestContext context, Vertx vertx) throws IOException {
 
     mockFailingDataSource();


### PR DESCRIPTION
## Description
Adapt to Knot.x JUnit 5 API changes: annotations rename, parallel tests execution.

## Motivation and Context
API changes + parallel tests execution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
