### PR TITLE
Feature/http action logs (#61)

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -68,5 +68,69 @@ Table below shows the behaviour of HttpAction depending on provided `responseOpt
 | application/text | false     | JSON           | JSON | _error     | -        |
 | application/text | true      | JSON           | JSON | _error     | -        |
 
+### Node log
+HTTP Action adds details about the request, response and occurred errors to [node log](https://github.com/Knotx/knotx-fragments/tree/master/handler/engine#node-log). 
+If the log level is `ERROR`, then only failing situations are logged: exception occurs during processing, response predicate is not valid, or status code is not between 200 and 300. 
+For the `INFO` log level all items are logged.
+
+Node log is presented as `JSON` and has the following structure:
+```json
+{
+  "request": REQUEST_DATA,
+  "response": RESPONSE_DATA,
+  "responseBody": RESPONSE_BODY,
+  "errors": LIST_OF_ERRORS
+}
+```
+`REQUEST_DATA` contains the following entries:
+ ```json
+{
+  "path": "/api/endpoint",
+  "requestHeaders": {
+    "Content-Type": "application/json"
+  }
+}
+```
+`RESPONSE_DATA` contains the following entries:
+```json
+{
+  "httpVersion": "HTTP_1_1",
+  "statusCode": "200",
+  "statusMessage": "OK",
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "trailers": {
+  },
+  "httpMethod": "GET",
+  "requestPath": "http://localhost/api/endpoint"
+}
+```
+`RESPONSE_BODY` contains the response received from service, it's text value.
+
+`LIST_OF_ERRORS` looks like the following:
+```json
+[
+  {
+    "className": "io.vertx.core.eventbus.ReplyException",
+    "message": "Expect content type application/text to be one of application/json"
+  },
+  {
+    "className": "some other exception...",
+    "message": "some other message..."
+  }
+]
+```
+The table below presents expected entries in node log on particular log levels depending on service response:
+
+| Response                                   | Log level  | Log entries   |
+| ------------------------------------------ | ---------- | ------------------------------------------ |
+| `_success`                                 | INFO       | REQUEST_DATA, RESPONSE_DATA, RESPONSE_BODY |
+| `_success`                                 | ERROR      |                                            |
+| exception occurs and `_error`              | INFO       | REQUEST_DATA, LIST_OF_ERRORS               |
+| exception occurs and `_error`              | ERROR      | REQUEST_DATA, LIST_OF_ERRORS               |
+| `_error` (e.g service responds with `500`) | INFO       | REQUEST_DATA, RESPONSE_DATA, RESPONSE_BODY |
+| `_error` (e.g service responds with `500`) | INFO       | REQUEST_DATA, RESPONSE_DATA                |
+
 ### Detailed configuration
 All configuration options are explained in details in the [Config Options Cheetsheet](https://github.com/Knotx/knotx-data-bridge/tree/master/http/action/docs/asciidoc/dataobjects.adoc).

--- a/http/action/docs/asciidoc/dataobjects.adoc
+++ b/http/action/docs/asciidoc/dataobjects.adoc
@@ -45,6 +45,9 @@ Sets the HTTP <code>port</code> the external service
 |[[endpointOptions]]`@endpointOptions`|`link:dataobjects.html#EndpointOptions[EndpointOptions]`|+++
 Set the details of the remote http endpoint location.
 +++
+|[[logLevel]]`@logLevel`|`String`|+++
+Set level of action logs.
++++
 |[[requestTimeoutMs]]`@requestTimeoutMs`|`Number (long)`|+++
 Configures the amount of time in milliseconds after which if the request does not return any
  data within, _timeout transition will be returned. Setting zero or a negative value disables
@@ -53,8 +56,8 @@ Configures the amount of time in milliseconds after which if the request does no
 |[[responseOptions]]`@responseOptions`|`link:dataobjects.html#ResponseOptions[ResponseOptions]`|-
 |[[webClientOptions]]`@webClientOptions`|`link:dataobjects.html#WebClientOptions[WebClientOptions]`|+++
 Set the <code>WebClientOptions</code> used by the HTTP client to communicate with remote http
- endpoint. See https://vertx.io/docs/vertx-web-client/dataobjects.html#WebClientOptions for
- the details what can be configured.
+ endpoint. See https://vertx.io/docs/vertx-web-client/dataobjects.html#WebClientOptions for the
+ details what can be configured.
 +++
 |===
 

--- a/http/action/src/main/java/io/knotx/databridge/http/action/EndpointResponse.java
+++ b/http/action/src/main/java/io/knotx/databridge/http/action/EndpointResponse.java
@@ -16,6 +16,7 @@
 package io.knotx.databridge.http.action;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.http.HttpVersion;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.ext.web.client.HttpResponse;
@@ -24,7 +25,9 @@ class EndpointResponse {
 
   private final HttpResponseStatus statusCode;
   private String statusMessage;
+  private HttpVersion httpVersion;
   private MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+  private MultiMap trailers = MultiMap.caseInsensitiveMultiMap();
   private Buffer body;
 
   EndpointResponse(HttpResponseStatus statusCode) {
@@ -34,9 +37,11 @@ class EndpointResponse {
   static EndpointResponse fromHttpResponse(HttpResponse<Buffer> response) {
     EndpointResponse endpointResponse = new EndpointResponse(
         HttpResponseStatus.valueOf(response.statusCode()));
-    endpointResponse.body = getResponsetBody(response);
+    endpointResponse.body = getResponseBody(response);
     endpointResponse.headers = response.headers();
+    endpointResponse.trailers = response.trailers();
     endpointResponse.statusMessage = response.statusMessage();
+    endpointResponse.httpVersion = response.version();
     return endpointResponse;
   }
 
@@ -49,6 +54,10 @@ class EndpointResponse {
     return headers;
   }
 
+  public MultiMap getTrailers() {
+    return trailers;
+  }
+
   public Buffer getBody() {
     return body;
   }
@@ -57,17 +66,23 @@ class EndpointResponse {
     return statusMessage;
   }
 
+  public HttpVersion getHttpVersion() {
+    return httpVersion;
+  }
+
   @Override
   public String toString() {
     return "EndpointResponse{" +
         "statusCode=" + statusCode +
         ", statusMessage='" + statusMessage + '\'' +
+        ", httpVersion=" + httpVersion +
         ", headers=" + headers +
+        ", trailers=" + trailers +
         ", body=" + body +
         '}';
   }
 
-  private static Buffer getResponsetBody(HttpResponse<Buffer> response) {
+  private static Buffer getResponseBody(HttpResponse<Buffer> response) {
     if (response.body() != null) {
       return response.body();
     } else {

--- a/http/action/src/main/java/io/knotx/databridge/http/action/HttpActionFactory.java
+++ b/http/action/src/main/java/io/knotx/databridge/http/action/HttpActionFactory.java
@@ -17,6 +17,7 @@ package io.knotx.databridge.http.action;
 
 import io.knotx.fragments.handler.api.Action;
 import io.knotx.fragments.handler.api.ActionFactory;
+import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
@@ -33,7 +34,8 @@ public class HttpActionFactory implements ActionFactory {
     if (doAction != null) {
       throw new IllegalArgumentException("Http Action can not wrap another action");
     }
-    return new HttpAction(vertx, new HttpActionOptions(config), alias);
+    return new HttpAction(vertx, new HttpActionOptions(config), alias,
+        ActionLogLevel.fromConfig(config));
   }
 
 }

--- a/http/action/src/main/java/io/knotx/databridge/http/action/HttpActionOptions.java
+++ b/http/action/src/main/java/io/knotx/databridge/http/action/HttpActionOptions.java
@@ -27,24 +27,17 @@ public class HttpActionOptions {
 
   private static final long DEFAULT_REQUEST_TIMEOUT = 0L;
 
-  private WebClientOptions webClientOptions;
-  private EndpointOptions endpointOptions;
-  private ResponseOptions responseOptions;
-  private long requestTimeoutMs;
+  private WebClientOptions webClientOptions = new WebClientOptions();
+  private EndpointOptions endpointOptions = new EndpointOptions();
+  private ResponseOptions responseOptions = new ResponseOptions();
+  private long requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT;
+  private String logLevel;
 
   public HttpActionOptions() {
-    init();
   }
 
   public HttpActionOptions(JsonObject json) {
-    init();
     HttpActionOptionsConverter.fromJson(json, this);
-  }
-
-  private void init() {
-    webClientOptions = new WebClientOptions();
-    responseOptions = new ResponseOptions();
-    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT;
   }
 
   public WebClientOptions getWebClientOptions() {
@@ -53,8 +46,8 @@ public class HttpActionOptions {
 
   /**
    * Set the {@code WebClientOptions} used by the HTTP client to communicate with remote http
-   * endpoint. See https://vertx.io/docs/vertx-web-client/dataobjects.html#WebClientOptions for
-   * the details what can be configured.
+   * endpoint. See https://vertx.io/docs/vertx-web-client/dataobjects.html#WebClientOptions for the
+   * details what can be configured.
    *
    * @param webClientOptions {@link WebClientOptions} object
    * @return a reference to this, so the API can be used fluently
@@ -105,6 +98,21 @@ public class HttpActionOptions {
     return this;
   }
 
+  public String getLogLevel() {
+    return logLevel;
+  }
+
+  /**
+   * Set level of action logs.
+   *
+   * @param logLevel alevel of action logs
+   * @return a reference to this, so the API can be used fluently
+   */
+  public HttpActionOptions setLogLevel(String logLevel) {
+    this.logLevel = logLevel;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "HttpActionOptions{" +
@@ -112,6 +120,7 @@ public class HttpActionOptions {
         ", endpointOptions=" + endpointOptions +
         ", responseOptions=" + responseOptions +
         ", requestTimeoutMs=" + requestTimeoutMs +
+        ", logLevel=" + logLevel +
         '}';
   }
 }

--- a/http/action/src/main/java/io/knotx/databridge/http/action/HttpResponseData.java
+++ b/http/action/src/main/java/io/knotx/databridge/http/action/HttpResponseData.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.databridge.http.action;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import java.util.List;
+import java.util.Map.Entry;
+
+public class HttpResponseData {
+
+  private static final String HTTP_VERSION_KEY = "httpVersion";
+  private static final String STATUS_CODE_KEY = "statusCode";
+  private static final String STATUS_MESSAGE_KEY = "statusMessage";
+  private static final String HEADERS_KEY = "headers";
+  private static final String TRAILERS_KEY = "trailers";
+
+  private final String httpVersion;
+  private final String statusCode;
+  private final String statusMessage;
+  private final MultiMap headers;
+  private final MultiMap trailers;
+
+  private HttpResponseData(String httpVersion, String statusCode, String statusMessage,
+      MultiMap headers, MultiMap trailers) {
+    this.httpVersion = httpVersion;
+    this.statusCode = statusCode;
+    this.statusMessage = statusMessage;
+    this.headers = headers;
+    this.trailers = trailers;
+  }
+
+  public static HttpResponseData from(HttpResponse<Buffer> response) {
+    return new HttpResponseData(
+        String.valueOf(response.version()),
+        String.valueOf(response.statusCode()),
+        response.statusMessage(),
+        response.headers(),
+        response.trailers()
+    );
+  }
+
+  public static HttpResponseData from(EndpointResponse endpointResponse) {
+    return new HttpResponseData(
+        String.valueOf(endpointResponse.getHttpVersion()),
+        String.valueOf(endpointResponse.getStatusCode()),
+        endpointResponse.getStatusMessage(),
+        endpointResponse.getHeaders(),
+        endpointResponse.getTrailers()
+    );
+  }
+
+  public JsonObject toJson() {
+    return new JsonObject()
+        .put(HTTP_VERSION_KEY, httpVersion)
+        .put(STATUS_CODE_KEY, statusCode)
+        .put(STATUS_MESSAGE_KEY, statusMessage)
+        .put(HEADERS_KEY, multiMapToJson(headers.entries()))
+        .put(TRAILERS_KEY, multiMapToJson(trailers.entries()));
+  }
+
+  public String getHttpVersion() {
+    return httpVersion;
+  }
+
+  public String getStatusCode() {
+    return statusCode;
+  }
+
+  public String getStatusMessage() {
+    return statusMessage;
+  }
+
+  public MultiMap getHeaders() {
+    return headers;
+  }
+
+  public MultiMap getTrailers() {
+    return trailers;
+  }
+
+  private static JsonObject multiMapToJson(List<Entry<String, String>> entries) {
+    JsonObject json = new JsonObject();
+    entries.forEach(e -> json.put(e.getKey(), e.getValue()));
+    return json;
+  }
+
+  @Override
+  public String toString() {
+    return "HttpResponseData{" +
+        "httpVersion='" + httpVersion + '\'' +
+        ", statusCode='" + statusCode + '\'' +
+        ", statusMessage='" + statusMessage + '\'' +
+        ", headers=" + headers +
+        ", trailers=" + trailers +
+        '}';
+  }
+}

--- a/http/action/src/test/java/io/knotx/databridge/http/action/HttpActionNodeLogTest.java
+++ b/http/action/src/test/java/io/knotx/databridge/http/action/HttpActionNodeLogTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2019 Knot.x Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.databridge.http.action;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.knotx.fragments.api.Fragment;
+import io.knotx.fragments.handler.api.actionlog.ActionLogLevel;
+import io.knotx.fragments.handler.api.domain.FragmentContext;
+import io.knotx.fragments.handler.api.domain.FragmentResult;
+import io.knotx.server.api.context.ClientRequest;
+import io.netty.util.internal.StringUtil;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.MultiMap;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(VertxExtension.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+public class HttpActionNodeLogTest {
+
+  private static final String ACTION_ALIAS = "httpAction";
+  private static final String RAW_BODY = "<html>Hello</html>";
+  private static final String APPLICATION_JSON = "application/json";
+  private static final String APPLICATION_TEXT = "application/text";
+  private static final String JSON = "JSON";
+  private static final String JSON_BODY = "{\n" +
+      "  \"id\": 21762532,\n" +
+      "  \"url\": \"http://knotx.io\",\n" +
+      "  \"label\": \"Product\"\n" +
+      "}";
+  private static final JsonObject EMPTY_JSON = new JsonObject();
+  private WireMockServer wireMockServer;
+
+  static Stream<Arguments> succeedingRequestsCasesWithLogLevels() {
+    return Stream.of(//Content-Type, forceJson, JSON predicate, Body, LogLevel
+        Arguments.of(APPLICATION_JSON, false, null, JSON_BODY, ActionLogLevel.INFO),
+        Arguments.of(APPLICATION_TEXT, true, null, JSON_BODY, ActionLogLevel.INFO),
+        Arguments.of(APPLICATION_JSON, false, JSON, JSON_BODY, ActionLogLevel.INFO),
+        Arguments.of(APPLICATION_JSON, false, null, JSON_BODY, ActionLogLevel.ERROR),
+        Arguments.of(APPLICATION_TEXT, true, null, JSON_BODY, ActionLogLevel.ERROR),
+        Arguments.of(APPLICATION_JSON, false, JSON, JSON_BODY, ActionLogLevel.ERROR)
+    );
+  }
+
+  static Stream<Arguments> failingBodyDecodingCasesWithLogLevels() {
+    return Stream.of(//Content-Type, forceJson, JSON predicate, Body, LogLevel
+        Arguments.of(APPLICATION_JSON, false, null, RAW_BODY, ActionLogLevel.INFO),
+        Arguments.of(APPLICATION_TEXT, true, null, RAW_BODY, ActionLogLevel.INFO),
+        Arguments.of(APPLICATION_JSON, false, JSON, RAW_BODY, ActionLogLevel.INFO),
+        Arguments.of(APPLICATION_JSON, false, null, RAW_BODY, ActionLogLevel.ERROR),
+        Arguments.of(APPLICATION_TEXT, true, null, RAW_BODY, ActionLogLevel.ERROR),
+        Arguments.of(APPLICATION_JSON, false, JSON, RAW_BODY, ActionLogLevel.ERROR)
+    );
+  }
+
+  static Stream<Arguments> webClientExceptionWithLogLevels() {
+    return Stream.of(//Content-Type, forceJson, JSON predicate, Body, LogLevel
+        Arguments.of(APPLICATION_TEXT, false, JSON, JSON_BODY, ActionLogLevel.INFO),
+        Arguments.of(APPLICATION_TEXT, true, JSON, JSON_BODY, ActionLogLevel.INFO),
+        Arguments.of(APPLICATION_TEXT, false, JSON, JSON_BODY, ActionLogLevel.ERROR),
+        Arguments.of(APPLICATION_TEXT, true, JSON, JSON_BODY, ActionLogLevel.ERROR)
+    );
+  }
+
+  @BeforeEach
+  void setUp() {
+    this.wireMockServer = new WireMockServer(options().dynamicPort());
+    this.wireMockServer.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    this.wireMockServer.stop();
+  }
+
+  @ParameterizedTest(name = "expect success transition and action log should contain info level messages")
+  @MethodSource("succeedingRequestsCasesWithLogLevels")
+  void actionLogShouldContainSuccessfulLogsOnlyWhenInfoLogLevel(String contentType,
+      boolean forceJson, String jsonPredicate, String responseBody, ActionLogLevel logLevel,
+      VertxTestContext testContext, Vertx vertx) throws Throwable {
+    String endpointPath = "/api/info-action-log";
+
+    ClientRequest clientRequest = prepareClientRequest(MultiMap.caseInsensitiveMultiMap(),
+        MultiMap.caseInsensitiveMultiMap(), endpointPath);
+    HttpAction tested = setupTestingInstances(vertx, endpointPath, responseBody, contentType,
+        jsonPredicate, forceJson, logLevel);
+
+    verifyExecution(tested, clientRequest, createFragment(), fragmentResult -> {
+      assertNotNull(fragmentResult.getNodeLog().getMap().get("logs"));
+      JsonObject logs = fragmentResult.getNodeLog().getJsonObject("logs");
+      if (ActionLogLevel.INFO.equals(logLevel)) {
+        assertNotNull(logs.getJsonObject("request"));
+        assertNotNull(logs.getString("responseBody"));
+        assertNotNull(logs.getJsonObject("response"));
+        assertNull(logs.getJsonObject("error"));
+        assertRequestLogs(logs.getJsonObject("request"));
+        assertResponseLogs(logs.getJsonObject("response"));
+      } else {
+        assertTrue(logs.isEmpty());
+      }
+    }, testContext);
+  }
+
+  @ParameterizedTest(name = "Expect request, response, and error logs when decoding exception occurs")
+  @MethodSource("failingBodyDecodingCasesWithLogLevels")
+  void actionLogShouldContainRequestResponseBodyAndError(String contentType, boolean forceJson,
+      String jsonPredicate, String responseBody, ActionLogLevel logLevel,
+      VertxTestContext testContext, Vertx vertx) throws Throwable {
+    String endpointPath = "/api/error-no-response";
+
+    ClientRequest clientRequest = prepareClientRequest(MultiMap.caseInsensitiveMultiMap(),
+        MultiMap.caseInsensitiveMultiMap(), endpointPath);
+    HttpAction tested = setupTestingInstances(vertx, endpointPath, responseBody, contentType,
+        jsonPredicate, forceJson, logLevel);
+
+    verifyExecution(tested, clientRequest, new Fragment("type", EMPTY_JSON, "expectedBody"),
+        fragmentResult -> {
+          assertNotNull(fragmentResult.getNodeLog().getMap().get("logs"));
+          JsonObject logs = fragmentResult.getNodeLog().getJsonObject("logs");
+          assertNotNull(logs.getJsonObject("request"));
+          if (ActionLogLevel.INFO.equals(logLevel)) {
+            assertNotNull(logs.getString("responseBody"));
+          }
+          assertNotNull(logs.getJsonObject("response"));
+          assertNotNull(logs.getJsonArray("errors"));
+          assertRequestLogs(logs.getJsonObject("request"));
+          assertErrorLogs(logs.getJsonArray("errors"));
+          assertResponseLogs(logs.getJsonObject("response"));
+        }, testContext);
+  }
+
+  @ParameterizedTest(name = "Expect request and error logs in node log when service fails")
+  @MethodSource("webClientExceptionWithLogLevels")
+  void actionLogShouldContainRequestAndErrorLogs(String contentType, boolean forceJson,
+      String jsonPredicate, String responseBody, ActionLogLevel logLevel,
+      VertxTestContext testContext, Vertx vertx) throws Throwable {
+    String endpointPath = "/api/exception-no-response";
+
+    ClientRequest clientRequest = prepareClientRequest(MultiMap.caseInsensitiveMultiMap(),
+        MultiMap.caseInsensitiveMultiMap(), endpointPath);
+    HttpAction tested = setupTestingInstances(vertx, endpointPath, responseBody, contentType,
+        jsonPredicate, forceJson, logLevel);
+
+    verifyExecution(tested, clientRequest, createFragment(), fragmentResult -> {
+      assertNotNull(fragmentResult.getNodeLog().getJsonObject("logs"));
+      JsonObject logs = fragmentResult.getNodeLog().getJsonObject("logs");
+      assertNotNull(logs.getJsonObject("request"));
+      assertNotNull(logs.getJsonArray("errors"));
+      assertNull(logs.getJsonObject("response"));
+      assertNull(logs.getJsonObject("responseBody"));
+      assertRequestLogs(logs.getJsonObject("request"));
+      assertErrorLogs(logs.getJsonArray("errors"));
+    }, testContext);
+  }
+
+  @ParameterizedTest(name = "Expect request, response and error logs in node log when service returns 500")
+  @EnumSource(ActionLogLevel.class)
+  void actionLogShouldContainRequestAndErrorLogsGiven500Response(ActionLogLevel logLevel,
+      VertxTestContext testContext, Vertx vertx) throws Throwable {
+    String endpointPath = "/api/exception-500-response";
+
+    ClientRequest clientRequest = prepareClientRequest(MultiMap.caseInsensitiveMultiMap(),
+        MultiMap.caseInsensitiveMultiMap(), endpointPath);
+    HttpAction tested = setupTestingInstances(vertx, endpointPath,
+        HttpStatus.SC_INTERNAL_SERVER_ERROR,
+        null, StringUtil.EMPTY_STRING, null, false, logLevel);
+
+    verifyExecution(tested, clientRequest, createFragment(), fragmentResult -> {
+      assertNotNull(fragmentResult.getNodeLog().getJsonObject("logs"));
+      JsonObject logs = fragmentResult.getNodeLog().getJsonObject("logs");
+      assertNotNull(logs.getJsonObject("request"));
+      assertNotNull(logs.getJsonObject("response"));
+      assertNotNull(logs.getJsonArray("errors"));
+      assertRequestLogs(logs.getJsonObject("request"));
+      assertResponseLogs(logs.getJsonObject("response"));
+      assertErrorLogs(logs.getJsonArray("errors"));
+    }, testContext);
+  }
+
+  private HttpAction setupTestingInstances(Vertx vertx, String endpointPath, String body,
+      String contentType, String jsonPredicate, boolean forceJson, ActionLogLevel logLevel) {
+    return setupTestingInstances(vertx, endpointPath, HttpStatus.SC_OK, body, contentType,
+        jsonPredicate, forceJson, logLevel);
+  }
+
+  private HttpAction setupTestingInstances(Vertx vertx, String endpointPath, int responseStatus,
+      String body, String contentType, String jsonPredicate, boolean forceJson,
+      ActionLogLevel logLevel) {
+    Set<String> predicates = new HashSet<>();
+    wireMockServer.stubFor(get(urlEqualTo(endpointPath))
+        .willReturn(aResponse().withBody(body)
+            .withHeader("Content-Type", contentType)
+            .withStatus(responseStatus)));
+
+    EndpointOptions endpointOptions = new EndpointOptions()
+        .setPath(endpointPath)
+        .setDomain("localhost")
+        .setPort(wireMockServer.port())
+        .setAllowedRequestHeaderPatterns(Collections.singletonList(Pattern.compile(".*")));
+
+    Optional.ofNullable(jsonPredicate).ifPresent(predicates::add);
+    ResponseOptions responseOptions = new ResponseOptions()
+        .setPredicates(predicates)
+        .setForceJson(forceJson);
+
+    return new HttpAction(vertx,
+        new HttpActionOptions()
+            .setEndpointOptions(endpointOptions)
+            .setResponseOptions(responseOptions),
+        ACTION_ALIAS, logLevel);
+  }
+
+  private static void assertRequestLogs(JsonObject requestLog) {
+    assertTrue(requestLog.containsKey("path"));
+    assertTrue(requestLog.containsKey("requestHeaders"));
+  }
+
+  private static void assertErrorLogs(JsonArray errorLog) {
+    errorLog.forEach(e -> {
+      ((JsonObject) e).containsKey("className");
+      ((JsonObject) e).containsKey("message");
+    });
+  }
+
+  private static void assertResponseLogs(JsonObject responseLog) {
+    assertTrue(responseLog.containsKey("httpVersion"));
+    assertTrue(responseLog.containsKey("httpMethod"));
+    assertTrue(responseLog.containsKey("statusCode"));
+    assertTrue(responseLog.containsKey("statusMessage"));
+    assertTrue(responseLog.containsKey("headers"));
+    assertTrue(responseLog.containsKey("trailers"));
+    assertTrue(responseLog.containsKey("requestPath"));
+  }
+
+  private void verifyExecution(HttpAction tested, ClientRequest clientRequest, Fragment fragment,
+      Consumer<FragmentResult> successAssertions,
+      VertxTestContext testContext) throws Throwable {
+    tested.apply(new FragmentContext(fragment, clientRequest),
+        testContext.succeeding(result -> {
+          testContext.verify(() -> successAssertions.accept(result));
+          testContext.completeNow();
+        }));
+    //then
+    assertTrue(testContext.awaitCompletion(60, TimeUnit.SECONDS));
+    if (testContext.failed()) {
+      throw testContext.causeOfFailure();
+    }
+  }
+
+  private ClientRequest prepareClientRequest(MultiMap clientRequestParams,
+      MultiMap headers, String clientRequestPath) {
+    ClientRequest clientRequest = new ClientRequest();
+    clientRequest.setPath(clientRequestPath);
+    clientRequest.setHeaders(headers);
+    clientRequest.setParams(clientRequestParams);
+    return clientRequest;
+  }
+
+  private Fragment createFragment() {
+    return new Fragment("type", EMPTY_JSON, "expectedBody");
+  }
+
+}


### PR DESCRIPTION
#85 Http Action log implementation.

<!--- Provide a general summary of your changes in the Title above -->

## Description
ActionLog support in HttpAction, logging on info and error levels when handling success or error responses
Moreover, we would like to add logs also for failing execution - every HttpAction call should be followed with proper logs. When an exception is thrown and is propagated to onError in `subscribe` in the `apply` method we want to log an exception name and its message - it concerns every kind of exception. Currently, it was impossible to achieve this effect - the failing HTTP call ended without any action logs. Moreover, DecodeException was caught during `FragmentResult` creation, without propagation to `onError`. Now, every HTTP call which ended with 200 status, but causing any exception while parsing will be treated now as succeeding with `_error` transition and error messages will be logged. 500 status will be still treated as success - its effect will remain in `onSuccess`. 
Logging flow which we're gonna achieve looks like the following:

- log request after request creation
- log service response
- log raw body received from service
- log processed result when processing ended with success

In case of a result processing error, the error message will be logged instead of the result, so logging flow it this case looks as following
- log request
- log response
- log raw body
- log error message

In case of request failure, we'll only log request and error message, the logging flow looks like:
- log request
- log error message

## Motivation and Context
We would like to add the ability to log ActionPayloads in HttpAction in order to have some debug or info messages.

## Breaking change
Exceptions are transformed to _error transition in Action
In 2.1: Handler gets all exceptions and ends with failure.
In 2.2: All exceptions are logged and _error transition is returned (handler ends with success).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.