### PR TITLE
Upgrade Gradle to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `knotx-data-bridge` will be documented in this file.
 # 1.6.0
 This version is dependency updates only, no new features or bugfixes. If you are upgrading from older than 1.5.0 version, follow the [Upgrade Notes for 1.5](https://knotx.io/blog/release-1_5_0/) first.
 - Upgraded Vert.x to 3.9.0
+- Upgrade Gradle to 5 and use a [native BOM support](https://docs.gradle.org/current/userguide/upgrading_version_4.html#rel5.0:bom_import)
+instead of [io.spring.dependency-management](https://plugins.gradle.org/plugin/io.spring.dependency-management) plugin.
+
 
 ## 1.5.0
 - [PR-37](https://github.com/Knotx/knotx-data-bridge/pull/37) - implementation of [fallback handling](https://github.com/Cognifide/knotx/issues/466) in data bridge

--- a/adapter-http/build.gradle
+++ b/adapter-http/build.gradle
@@ -19,6 +19,6 @@ description = "Knot.x Data Source Http"
 compileJava.dependsOn annotationProcessing
 
 dependencies {
-    compile project(':knotx-databridge-api')
-    compile "io.vertx:vertx-web-client"
+    api project(':knotx-databridge-api')
+    implementation "io.vertx:vertx-web-client"
 }

--- a/adapter-http/src/main/java/io/knotx/databridge/http/package-info.java
+++ b/adapter-http/src/main/java/io/knotx/databridge/http/package-info.java
@@ -13,19 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@ModuleGen(name = "knotx-databridge-adapter", groupPackage = "io.knotx")
+package io.knotx.databridge.http;
 
-description = "Knot.x Data Bridge Core"
-
-compileJava.dependsOn annotationProcessing
-
-configurations {
-    testResources
-}
-
-dependencies {
-  api project(':knotx-databridge-api')
-  testImplementation group: 'io.knotx', name: 'knotx-core', version: "${project.version}", classifier: 'tests'
-  testResources sourceSets.test.output
-}
-
-
+import io.vertx.codegen.annotations.ModuleGen;

--- a/api/src/main/java/io/knotx/databridge/api/package-info.java
+++ b/api/src/main/java/io/knotx/databridge/api/package-info.java
@@ -13,19 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@ModuleGen(name = "knotx-databridge-api", groupPackage = "io.knotx")
+package io.knotx.databridge.api;
 
-description = "Knot.x Data Bridge Core"
-
-compileJava.dependsOn annotationProcessing
-
-configurations {
-    testResources
-}
-
-dependencies {
-  api project(':knotx-databridge-api')
-  testImplementation group: 'io.knotx', name: 'knotx-core', version: "${project.version}", classifier: 'tests'
-  testResources sourceSets.test.output
-}
-
-
+import io.vertx.codegen.annotations.ModuleGen;

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@
  */
 
 plugins {
-  id 'io.spring.dependency-management' version '1.0.5.RELEASE' apply false
   id 'maven'
 }
 
@@ -35,7 +34,6 @@ subprojects { subproject ->
   group = 'io.knotx'
 
   apply plugin: 'java-library'
-  apply plugin: 'io.spring.dependency-management'
 
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
@@ -46,40 +44,34 @@ subprojects { subproject ->
     options.incremental = true
   }
 
-  dependencyManagement {
-    imports {
-      mavenBom "io.knotx:knotx-dependencies:${project.version}"
-    }
-  }
-
   dependencies {
-    compile 'io.knotx:knotx-core'
+    implementation platform("io.knotx:knotx-dependencies:${project.version}")
+    api 'io.knotx:knotx-core'
 
-    compile 'io.vertx:vertx-core'
-    compile 'io.vertx:vertx-service-proxy'
-    compile 'io.vertx:vertx-rx-java2'
+    implementation 'io.vertx:vertx-core'
+    implementation 'io.vertx:vertx-service-proxy'
+    implementation 'io.vertx:vertx-rx-java2'
+    implementation 'io.vertx:vertx-codegen'
+    implementation 'io.vertx:vertx-rx-java2-gen'
 
-    compileOnly 'io.vertx:vertx-codegen'
-    compileOnly 'io.vertx:vertx-rx-java2-gen'
+    annotationProcessor group: "io.vertx", name: "vertx-codegen", version: "3.9.0", classifier: "processor"
+    annotationProcessor group: "io.vertx", name: "vertx-service-proxy", version: "3.9.0", classifier: "processor"
+    annotationProcessor group: "io.vertx", name: "vertx-rx-java2-gen", version: "3.9.0"
 
     // Test dependencies
-    testCompile 'org.junit.jupiter:junit-jupiter-api'
-    testCompile 'org.junit.jupiter:junit-jupiter-engine'
-    testCompile 'org.junit.jupiter:junit-jupiter-params'
-    testCompile 'org.junit.jupiter:junit-jupiter-migrationsupport'
-    testCompile 'org.junit.vintage:junit-vintage-engine'
-    testCompile 'uk.co.datumedge:hamcrest-json'
-    testCompile 'org.hamcrest:hamcrest-all'
-    testCompile 'com.github.tomakehurst:wiremock'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testImplementation 'org.junit.jupiter:junit-jupiter-migrationsupport'
+    testImplementation 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'uk.co.datumedge:hamcrest-json'
+    testImplementation 'org.hamcrest:hamcrest-all'
+    testImplementation 'com.github.tomakehurst:wiremock'
 
-    testCompileOnly 'io.vertx:vertx-codegen'
-    testCompile 'io.vertx:vertx-config'
-    testCompile 'io.vertx:vertx-junit5'
-    testCompile 'io.knotx:knotx-mocks'
-    testCompile 'io.knotx:knotx-junit5'
-
-    annotationProcessor 'io.vertx:vertx-codegen'
-    annotationProcessor 'io.vertx:vertx-service-proxy'
+    testImplementation 'io.vertx:vertx-config'
+    testImplementation 'io.vertx:vertx-junit5'
+    testImplementation 'io.knotx:knotx-mocks'
+    testImplementation 'io.knotx:knotx-junit5'
   }
 
   sourceSets {
@@ -101,7 +93,8 @@ subprojects { subproject ->
 
   task annotationProcessing(type: JavaCompile, group: 'build') { // codegen
     source = sourceSets.main.java
-    classpath = configurations.compile + configurations.compileOnly + configurations.annotationProcessor
+    options.annotationProcessorPath = configurations.annotationProcessor
+    classpath = configurations.compileClasspath + configurations.runtimeClasspath + fileTree('src/main/resources')
     destinationDir = project.file('src/main/generated')
     options.compilerArgs = [
         "-proc:only",

--- a/core/src/main/java/io/knotx/databridge/core/package-info.java
+++ b/core/src/main/java/io/knotx/databridge/core/package-info.java
@@ -13,19 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@ModuleGen(name = "knotx-databridge-core", groupPackage = "io.knotx")
+package io.knotx.databridge.core;
 
-description = "Knot.x Data Bridge Core"
-
-compileJava.dependsOn annotationProcessing
-
-configurations {
-    testResources
-}
-
-dependencies {
-  api project(':knotx-databridge-api')
-  testImplementation group: 'io.knotx', name: 'knotx-core', version: "${project.version}", classifier: 'tests'
-  testResources sourceSets.test.output
-}
-
-
+import io.vertx.codegen.annotations.ModuleGen;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it-test/build.gradle
+++ b/it-test/build.gradle
@@ -17,12 +17,12 @@
 description = "Knot.x Data Bridge Integration Tests"
 
 dependencies {
-  compile project(':knotx-databridge-core')
-  compile project(':knotx-databridge-adapter-http')
+  implementation project(':knotx-databridge-core')
+  implementation project(':knotx-databridge-adapter-http')
 
-  compile "io.vertx:vertx-web-client"
+  implementation "io.vertx:vertx-web-client"
 
-  testCompile project(path: ':knotx-databridge-core', configuration: 'testResources')
+  testImplementation project(path: ':knotx-databridge-core', configuration: 'testResources')
 }
 
 sourceSets {


### PR DESCRIPTION
<!-- Please update the sections below that apply, remove the rest -->

## Description
Update to gradle 5

## Motivation and Context
Upgrade Gradle to 5 to use a [native BOM support](https://docs.gradle.org/current/userguide/upgrading_version_4.html#rel5.0:bom_import)
instead of [io.spring.dependency-management](https://plugins.gradle.org/plugin/io.spring.dependency-management) plugin which causes stack-manager to download all dependencies from BOM.